### PR TITLE
feat: xy.plot()

### DIFF
--- a/floodlight/core/pitch.py
+++ b/floodlight/core/pitch.py
@@ -174,7 +174,7 @@ class Pitch:
             Axes from matplotlib library on which the playing field is plotted. If ax is
             None, a default-sized matplotlib.axes object is created.
         kwargs:
-            Optional keyworded arguments ('linewidth', 'zorder', 'scalex', 'scaley'}
+            Optional keyworded arguments {'linewidth', 'zorder', 'scalex', 'scaley'}
             which can be used for the plot functions from matplotlib. The kwargs are
             only passed to all the plot functions of matplotlib.
 

--- a/floodlight/core/xy.py
+++ b/floodlight/core/xy.py
@@ -1,10 +1,13 @@
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import Tuple
+from typing import Union
 
+import matplotlib
 import numpy as np
 
 from floodlight.utils.types import Numeric
+from floodlight.vis import xy_positions
 
 
 @dataclass
@@ -217,3 +220,42 @@ class XY:
             )
 
         return xy_sliced
+
+    def plot(
+        self,
+        type: str,
+        t: Union[int, Tuple[int, int]],
+        ball: bool = False,
+        ax: matplotlib.axes = None,
+        **kwargs,
+    ) -> matplotlib.axes:
+        """Wrapper function that calls the actual plotting methods based on the type.
+
+        Parameters
+        ----------
+        type: str
+            One of {positions, trajectories}. Determines which plotting function is
+            called.
+        t: Union[int, Tuple [int, int]]
+            Frame for which postions should be plotted if type == 'positions', or a
+            range of frames if type == 'trajectories'.
+        ball: bool, optional
+            If ball == True the positions and lines are modified.
+        ax: matplotlib.axes, optional
+            Axes from matplotlib library to plot on. If ax is None, a default-sized
+            matplotlib.axes object is created.
+        kwargs:
+            Optional keyworded arguments {'color', 'zorder', 'marker', 'linestyle',
+            'alpha'} which can be used for the plot functions from matplotlib.
+            The kwargs are only passed to all the plot functions of matplotlib.
+        Returns
+        -------
+        matplotlib.axes
+            An axes with the specified plot type.
+        """
+
+        # Get function for the given type
+        plot_function = getattr(xy_positions, f"plot_{type}")
+
+        # Call function for given type and return it
+        return plot_function(self.xy, t, ball, ax=ax, **kwargs)

--- a/floodlight/vis/xy_positions.py
+++ b/floodlight/vis/xy_positions.py
@@ -6,16 +6,24 @@ def plot_positions(
     xy: np.ndarray, frame: int, ball: bool, ax: matplotlib.axes, **kwargs
 ) -> matplotlib.axes:
     """
-        Plots x and y positions for a given frame on a matplotlib.axes.
+        Plots positions for a given frame on a matplotlib.axes.
     plot
         Parameters
         -----------
-
+        xy: np.ndarray
+            Full data array containing x- and y-coordinates, where each player's
+            coordinates occupy two consecutive columns.
+        frame: int
+            Frame for which the positions are plotted.
+        ball: bool
+            If set to False marker="o". Else marker="."
+        ax: matplotlib.axes
+            Axes from matplotlib library on which the positions are plotted.
 
         Returns
         -------
         matplotib.axes
-            A matplotlib.axes to which x and y positions of a given frame are added.
+            A matplotlib.axes on which x and y-positions of a given frame are plotted.
     """
 
     # kwargs which are used to configure the plot with default values.

--- a/floodlight/vis/xy_positions.py
+++ b/floodlight/vis/xy_positions.py
@@ -1,0 +1,49 @@
+import matplotlib
+import numpy as np
+
+
+def plot_positions(
+    xy: np.ndarray, frame: int, ball: bool, ax: matplotlib.axes, **kwargs
+) -> matplotlib.axes:
+    """
+        Plots x and y positions for a given frame on a matplotlib.axes.
+    plot
+        Parameters
+        -----------
+
+
+        Returns
+        -------
+        matplotib.axes
+            A matplotlib.axes to which x and y positions of a given frame are added.
+    """
+
+    # kwargs which are used to configure the plot with default values.
+    # All other kwargs are just getting passed to the scatter() method.
+    marker = kwargs.pop("marker", "o" if not ball else ".")
+    color = kwargs.pop("color", "black")
+    zorder = kwargs.pop("zorder", 1)
+
+    # plotting the positions
+    # if ball is false
+    if not ball:
+        ax.scatter(
+            x=xy[frame, ::2],
+            y=xy[frame, 1::2],
+            marker=marker,
+            color=color,
+            zorder=zorder,
+            **kwargs,
+        )
+    # if ball is true
+    elif ball:
+        ax.scatter(
+            x=xy[frame, ::2],
+            y=xy[frame, 1::2],
+            marker=marker,
+            color=color,
+            zorder=zorder,
+            **kwargs,
+        )
+
+    return ax

--- a/floodlight/vis/xy_positions.py
+++ b/floodlight/vis/xy_positions.py
@@ -1,36 +1,67 @@
 from typing import Tuple
 
 import matplotlib
+import matplotlib.pyplot as plt
 import numpy as np
 
-from floodlight.utils.types import Numeric
+
+def handle_ax(func):
+    """Decorator function that handles if matplotlib.axes are given as an argument or
+        not.
+
+    Parameters
+    ---------
+    func: xy_positions.<method>
+        Function object that needs a matplotlib.axes as an argument. If ax == None an
+        axes is created an passed to func as a keyworded argument.
+
+    Returns
+    ------
+    func: xy_positions.<method>()
+        Decorated function.
+    """
+
+    def wrapper(*args, **kwargs):
+
+        if not kwargs.get("ax"):  # If no matplotlib.axes is not given (ax == None)
+            kwargs.pop("ax")  # an axes is created.
+            ax = plt.subplots()[1]
+            return func(*args, ax=ax, **kwargs)
+
+        return func(*args, **kwargs)  # If matplotlib.axes is given nothing changes and
+        # the function is returned with the given *args
+        # and **kwargs
+
+    return wrapper
 
 
+@handle_ax
 def plot_positions(
     xy: np.ndarray, frame: int, ball: bool, ax: matplotlib.axes, **kwargs
 ) -> matplotlib.axes:
-    """
-        Plots positions for a given frame on a matplotlib.axes.
-    plot
-        Parameters
-        -----------
-        xy: np.ndarray
-            Full data array containing x- and y-coordinates, where each player's
-            coordinates occupy two consecutive columns.
-        frame: int
-            Frame for which the positions are plotted.
-        ball: bool
-            If set to False marker="o". Else marker="."
-        ax: matplotlib.axes
-            Axes from matplotlib library on which the positions are plotted.
-        kwargs:
-            Optional keyworded arguments e.g. {'color', 'zorder', 'marker'}
-            which can be used for the plot functions from matplotlib. The kwargs are
-            only passed to all the plot functions of matplotlib.
-        Returns
-        -------
-        matplotib.axes
-            A matplotlib.axes on which x and y-positions of a given frame are plotted.
+    """Plots positions for a given frame of the xy-array on a matplotlib.axes.
+
+    Parameters
+    -----------
+    xy: np.ndarray
+        Full data array containing x- and y-coordinates, where each player's
+        coordinates occupy two consecutive columns.
+    frame: int
+        Frame for which the positions are plotted.
+    ball: bool
+        If set to False marker="o". Else marker="."
+    ax: matplotlib.axes
+        Axes from matplotlib library on which the positions are plotted.
+    kwargs:
+        Optional keyworded arguments e.g. {'color', 'zorder', 'marker'}
+        which can be used for the plot functions from matplotlib. The kwargs are
+        only passed to all the plot functions of matplotlib.
+
+    Returns
+    -------
+    matplotib.axes
+        A matplotlib.axes on which x and y-positions of a given frame from the
+        xy-array are plotted.
     """
 
     # kwargs which are used to configure the plot with default values.
@@ -64,37 +95,38 @@ def plot_positions(
     return ax
 
 
+@handle_ax
 def plot_trajectories(
     xy: np.ndarray,
-    frame_range: Tuple[Numeric, Numeric],
+    frame_range: Tuple[int, int],
     ball: bool,
     ax: matplotlib.axes,
     **kwargs,
 ) -> matplotlib.axes:
-    """
-        Plots positions for a given frame on a matplotlib.axes.
-    plot
-        Parameters
-        -----------
-        xy: np.ndarray
-            Full data array containing x- and y-coordinates, where each player's
-            coordinates occupy two consecutive columns.
-        frame_range: Tuple[Numeric, Numeric]
-            Frame range for which trajectories are plotted. From frame_range[0] to
-            frame_range[1] a trajectory is plotted.
-        ball: bool
-            If set to False marker="o". Else marker="."
-        ax: matplotlib.axes
-            Axes from matplotlib library on which the positions are plotted.
-        kwargs:
-            Optional keyworded arguments e.g.{'linewidth', 'zorder', 'linestyle',
-            'alpha'} which can be used for the plot functions from matplotlib.
-            The kwargs are only passed to all the plot functions of matplotlib.
+    """Plots trajectories for a given range of frames  of the xyy-array on a
+    matplotlib.axes.
 
-        Returns
-        -------
-        matplotib.axes
-            A matplotlib.axes on which x and y-positions of a given frame are plotted.
+    Parameters
+    -----------
+    xy: np.ndarray
+        Full data array containing x- and y-coordinates, where each player's
+        coordinates occupy two consecutive columns.
+    frame_range: Tuple[int, int]
+        From frame_range[0] to frame_range[1] a trajectory is plotted.
+    ball: bool
+        If set to False marker="o". Else marker="."
+    ax: matplotlib.axes
+        Axes from matplotlib library on which the positions are plotted.
+    kwargs:
+        Optional keyworded arguments e.g.{'linewidth', 'zorder', 'linestyle',
+        'alpha'} which can be used for the plot functions from matplotlib.
+        The kwargs are only passed to all the plot functions of matplotlib.
+
+    Returns
+    -------
+    matplotib.axes
+        A matplotlib.axes on which trajectories of a given frame from the
+        xy-array are plotted.
     """
 
     # kwargs which are used to configure the plot with default values.
@@ -104,6 +136,8 @@ def plot_trajectories(
     # ball trajectories are thinner per default
     linewidth = kwargs.pop("linewidth", 1 if not ball else 0.5)
 
+    # iterating over every object (for instance players) in the xy-array and plot the
+    # movement over the given frame_range
     for i in range(0, len(xy[0]), 2):
         x = xy[frame_range[0] : frame_range[1], i]
         y = xy[frame_range[0] : frame_range[1], i + 1]

--- a/floodlight/vis/xy_positions.py
+++ b/floodlight/vis/xy_positions.py
@@ -1,5 +1,9 @@
+from typing import Tuple
+
 import matplotlib
 import numpy as np
+
+from floodlight.utils.types import Numeric
 
 
 def plot_positions(
@@ -19,7 +23,10 @@ def plot_positions(
             If set to False marker="o". Else marker="."
         ax: matplotlib.axes
             Axes from matplotlib library on which the positions are plotted.
-
+        kwargs:
+            Optional keyworded arguments e.g. {'color', 'zorder', 'marker'}
+            which can be used for the plot functions from matplotlib. The kwargs are
+            only passed to all the plot functions of matplotlib.
         Returns
         -------
         matplotib.axes
@@ -29,7 +36,7 @@ def plot_positions(
     # kwargs which are used to configure the plot with default values.
     # All other kwargs are just getting passed to the scatter() method.
     marker = kwargs.pop("marker", "o" if not ball else ".")
-    color = kwargs.pop("color", "black")
+    color = kwargs.pop("color", "black" if not ball else "grey")
     zorder = kwargs.pop("zorder", 1)
 
     # plotting the positions
@@ -53,5 +60,53 @@ def plot_positions(
             zorder=zorder,
             **kwargs,
         )
+
+    return ax
+
+
+def plot_trajectories(
+    xy: np.ndarray,
+    frame_range: Tuple[Numeric, Numeric],
+    ball: bool,
+    ax: matplotlib.axes,
+    **kwargs,
+) -> matplotlib.axes:
+    """
+        Plots positions for a given frame on a matplotlib.axes.
+    plot
+        Parameters
+        -----------
+        xy: np.ndarray
+            Full data array containing x- and y-coordinates, where each player's
+            coordinates occupy two consecutive columns.
+        frame_range: Tuple[Numeric, Numeric]
+            Frame range for which trajectories are plotted. From frame_range[0] to
+            frame_range[1] a trajectory is plotted.
+        ball: bool
+            If set to False marker="o". Else marker="."
+        ax: matplotlib.axes
+            Axes from matplotlib library on which the positions are plotted.
+        kwargs:
+            Optional keyworded arguments e.g.{'linewidth', 'zorder', 'linestyle',
+            'alpha'} which can be used for the plot functions from matplotlib.
+            The kwargs are only passed to all the plot functions of matplotlib.
+
+        Returns
+        -------
+        matplotib.axes
+            A matplotlib.axes on which x and y-positions of a given frame are plotted.
+    """
+
+    # kwargs which are used to configure the plot with default values.
+    # All other kwargs are just getting passed to the plot() method.
+    color = kwargs.pop("color", "black")
+    zorder = kwargs.pop("zorder", 1)
+    # ball trajectories are thinner per default
+    linewidth = kwargs.pop("linewidth", 1 if not ball else 0.5)
+
+    for i in range(0, len(xy[0]), 2):
+        x = xy[frame_range[0] : frame_range[1], i]
+        y = xy[frame_range[0] : frame_range[1], i + 1]
+        ax.plot(x, y, color=color, zorder=zorder, linewidth=linewidth, **kwargs)
 
     return ax


### PR DESCRIPTION
First draft contains:
- wrapper function xy.plot that calls the actual plotting functions from the vis.xy_positions.py module.
- plot_positions function that plots all positions for a given frame of the XY.xy-array.
- plot_trajectories function that plots the trajectories of all positions for a given frame range of the XY.xy-array.
- handle_ax decorator function that handles the ax (matplotlib.axes) argument. 

I would be interested in your opinion regarding the following points:
- I am not sure if vis.xy_positions.py is a good name for the module?
- I am calling the actual plotting methods in another way compared to the pitch.plot function ( -> getattr(xy_positions, f"plot_{type}")
- I implemented a decorator function (handle_ax()) that creates an matplotlib.axes if not given. I am not sure if this is good  or just unnecessary code that could be easily worked around with one line of code in the xy.plot function ( -> ax = ax or plt.subplots()[1]. The idea was that we could pass this decorator to all plotting functions in the future and handle the ax argument this way.

I am looking forward to your comments.