### PR TITLE
feat: add statsbomb open data parser and dataset

### DIFF
--- a/docs/source/modules/io/io.rst
+++ b/docs/source/modules/io/io.rst
@@ -12,6 +12,7 @@ datasets.
    dfl
    kinexon
    opta
+   statsbomb
    statsperform
    tracab
 

--- a/docs/source/modules/io/statsbomb.rst
+++ b/docs/source/modules/io/statsbomb.rst
@@ -1,0 +1,6 @@
+=======================
+floodlight.io.statsbomb
+=======================
+
+.. automodule:: floodlight.io.statsbomb
+    :members:

--- a/floodlight/core/pitch.py
+++ b/floodlight/core/pitch.py
@@ -63,7 +63,7 @@ class Pitch:
             The name of the template the pitch should follow. Currently supported are
             {'dfl', 'opta', 'statsperform', 'tracab'}.
         kwargs:
-            You may pass optional arguments (`length`, `width`, `sport`} used for class
+            You may pass optional arguments (`length`, `width`, `sport`) used for class
             instantiation. For some data providers, additional kwargs are needed to
             represent their format correctly. For example, pass the `length` and `width`
             argument to create a Pitch object in the 'chyronhego_international' format.
@@ -137,15 +137,23 @@ class Pitch:
                 width=kwargs.get("width"),
                 sport=kwargs.get("sport"),
             )
+        elif template_name == "eigd":
+            return cls(
+                xlim=(0, 40),
+                ylim=(0, 20),
+                unit="m",
+                boundaries="fixed",
+                length=40,
+                width=20,
+                sport="handball",
+            )
         elif template_name == "statsbomb":
             return cls(
                 xlim=(0.0, 120.0),
                 ylim=(0.0, 80.0),
-                unit="relativepercent",
+                unit="normed",
                 boundaries="flexible",
-                length=120,
-                width=80,
-                sport=kwargs.get("sport"),
+                sport="football",
             )
         else:
             raise ValueError(f"Unsupported template name '{template_name}'")

--- a/floodlight/core/pitch.py
+++ b/floodlight/core/pitch.py
@@ -142,9 +142,9 @@ class Pitch:
                 xlim=(0.0, 120.0),
                 ylim=(0.0, 80.0),
                 unit="relativepercent",
-                boundaries="fixed",
-                length=kwargs.get("length"),
-                width=kwargs.get("width"),
+                boundaries="flexible",
+                length=120,
+                width=80,
                 sport=kwargs.get("sport"),
             )
         else:

--- a/floodlight/core/pitch.py
+++ b/floodlight/core/pitch.py
@@ -137,6 +137,16 @@ class Pitch:
                 width=kwargs.get("width"),
                 sport=kwargs.get("sport"),
             )
+        elif template_name == "statsbomb":
+            return cls(
+                xlim=(0.0, 120.0),
+                ylim=(0.0, 80.0),
+                unit="relativepercent",
+                boundaries="fixed",
+                length=kwargs.get("length"),
+                width=kwargs.get("width"),
+                sport=kwargs.get("sport"),
+            )
         else:
             raise ValueError(f"Unsupported template name '{template_name}'")
 

--- a/floodlight/io/datasets.py
+++ b/floodlight/io/datasets.py
@@ -287,65 +287,44 @@ class StatsBombOpenDataset:
     total of eight different competitions (Women's World Cup, FIFA World Cup, UEFA Euro,
     Champions League, FA Women's Super League, NWSL, Premier League, and La Liga). The
     competition with the most matches is La Liga where StatsBomb provides data for every
-    one of the 520 matches where Lionel Messi played for FC Barcelona. In addition, for
-    51 matches from the UEFA Euro 2020 additional StatsBomb360 data is available. This
-    data contains the tracked positions of (some) players at the captured events of
+    one of the 520 matches ever played by Lionel Messi for FC Barcelona. In addition,
+    for 51 matches from the UEFA Euro 2020 additional StatsBomb360 data is available.
+    This data contains the tracked positions of (some) players at the captured events of
     these matches. As the data is constantly updated, we provide an overview over the
     stats here but refer to the official repository for up-to-date information (last
-    modified 26.04.2022).
-
-        competitions = ['Champions League', 'FA Women's Super League', 'FIFA World Cup',
-                        'La Liga', 'NWSL' 'Premier League' 'UEFA Euro'
-                        'Women's World Cup']
-
-        seasons = {
-            'Champions League' : ['1999/2000', '2003/2004', '2004/2005', '2006/2007',
-                                  '2008/2009', '2009/2010', '2010/2011', '2011/2012',
-                                  '2012/2013', '2013/2014', '2014/2015', '2015/2016',
-                                  '2016/2017', '2017/2018', '2018/2019'],
-            'FA Women's Super League' : ['2018/2019', '2019/2020', '2020/2021'],
-            'FIFA World Cup': ['2018'],
-            'La Liga': ['2004/2005', '2005/2006', '2006/2007', '2007/2008', '2008/2009',
-                        '2009/2010', '2010/2011', '2011/2012', '2012/2013', '2013/2014',
-                        '2014/2015', '2015/2016', '2016/2017', '2017/2018', '2018/2019',
-                        '2019/2020', '2020/2021'],
-            'NWSL': ['2018'],
-            'Premier League': ['2003/2004'],
-            'UEFA Euro': ['2020'],
-            'Women's World Cup': ['2019'],
-            }
+    modified 27.04.2022)::
 
         number_of_matches = {
-            'Champions League': {
-                1999/2000 : 0, 2003/2004 : 1, 2004/2005 : 1, 2006/2007 : 1,
-                2008/2009 : 1, 2009/2010 : 1, 2010/2011 : 1,2011/2012 : 1,
-                2012/2013 : 1, 2013/2014 : 1,2014/2015 : 1, 2015/2016 : 1,
-                2016/2017 : 1, 2017/2018 : 1, 2018/2019 : 1,
+            "Champions League": {
+                '1999/2000' : 0, '2003/2004' : 1, '2004/2005' : 1, '2006/2007' : 1,
+                '2008/2009' : 1, '2009/2010' : 1, '2010/2011' : 1, '2011/2012' : 1,
+                '2012/2013' : 1, '2013/2014' : 1, '2014/2015' : 1, '2015/2016' : 1,
+                '2016/2017' : 1, '2017/2018' : 1, '2018/2019' : 1,
                 },
-            'FA Women's Super League': {
-                2018/2019 : 108, 2019/2020 : 87, 2020/2021 : 131,
+            "FA Women's Super League": {
+                '2018/2019' : 108, '2019/2020' : 87, '2020/2021' : 131,
                 },
-            'FIFA World Cup': {
-                2018 : 64,
+            "FIFA World Cup": {
+                '2018' : 64,
                 },
-            'La Liga': {
-                2004/2005: 7, 2005/2006 : 17, 2006/2007 : 26, 2007/2008 : 28,
-                2008/2009 : 31, 2009/2010 : 35, 2010/2011 : 33, 2011/2012 : 37,
-                2012/2013 : 32, 2013/2014 : 31, 2014/2015 : 38, 2015/2016 : 33,
-                2016/2017 : 34, 2017/2018 : 36, 2018/2019 : 34, 2019/2020 : 33,
-                2020/2021 : 35,
+            "La Liga": {
+                '2004/2005': 7, '2005/2006' : 17, '2006/2007' : 26, '2007/2008' : 28,
+                '2008/2009' : 31, '2009/2010' : 35, '2010/2011' : 33, '2011/2012' : 37,
+                '2012/2013' : 32, '2013/2014' : 31, '2014/2015' : 38, '2015/2016' : 33,
+                '2016/2017' : 34, '2017/2018' : 36, '2018/2019' : 34, '2019/2020' : 33,
+                '2020/2021' : 35,
                 },
-            'NWSL': {
-                2018 : 36,
+            "NWSL": {
+                '2018' : 36,
                 },
-            'Premier League': {
-                2003/2004 : 33,
+            "Premier League": {
+                '2003/2004' : 33,
                 },
-            'UEFA Euro' : {
-                2020 : 51,
+            "UEFA Euro" : {
+                '2020' : 51,
                 },
-            'Women's World Cup': {
-                2019 : 52,
+            "Women's World Cup": {
+                '2019' : 52,
                 },
         }
 
@@ -360,7 +339,6 @@ class StatsBombOpenDataset:
     >>> links = dataset.get_links("UEFA Euro", "2020", 10)
     # get the corresponding pitch
     >>> pitch = dataset.get_pitch()
-
     # get events for every El Clásico ever played by Lionel Messi in Camp Nou
     >>> clasico_events = []
     >>> for season in dataset.links_match_to_mID["La Liga"]:

--- a/floodlight/io/datasets.py
+++ b/floodlight/io/datasets.py
@@ -46,7 +46,7 @@ class EIGDDataset:
     # get one sample
     >>> teamA, teamB, ball = dataset.get(match="48dcd3", segment="00-06-00")
     # get the corresponding pitch
-    >>> pitch = dataset.get_pitch
+    >>> pitch = dataset.pitch
 
 
     References
@@ -117,7 +117,7 @@ class EIGDDataset:
         )
 
     @property
-    def get_pitch(self) -> Pitch:
+    def pitch(self) -> Pitch:
         """Returns a Pitch object corresponding to the EIGD-data."""
         return Pitch(
             xlim=(0, 40),
@@ -160,7 +160,7 @@ class ToyDataset:
     >>>     ballstatus,
     >>> ) = dataset.get(segment="HT1")
     # get the corresponding pitch
-    >>> pitch = dataset.get_pitch
+    >>> pitch = dataset.pitch
 
     """
 
@@ -255,7 +255,7 @@ class ToyDataset:
         return data_objects
 
     @property
-    def get_pitch(self) -> Pitch:
+    def pitch(self) -> Pitch:
         """Returns a Pitch object corresponding to the Toy Dataset."""
         return Pitch(
             xlim=(-52.5, 52.5),
@@ -346,7 +346,7 @@ class StatsBombOpenDataset:
     # get one sample
     >>> events = dataset.get(competition="La Liga", season="2020/2021", match_num=35)
     # get the corresponding pitch
-    >>> pitch = dataset.get_pitch
+    >>> pitch = dataset.pitch
     """
 
     def __init__(self, dataset_path="statsbomb_dataset"):
@@ -419,6 +419,11 @@ class StatsBombOpenDataset:
         """
         events = None
         return events
+
+    @property
+    def pitch(self) -> Pitch:
+        """Returns a Pitch object corresponding to the Toy Dataset."""
+        return Pitch.from_template("statsbomb")
 
     def create_match_ids_from_files(self):
         """Creates a dictionary that contains all available matches for every

--- a/floodlight/io/datasets.py
+++ b/floodlight/io/datasets.py
@@ -533,7 +533,7 @@ class StatsBombOpenDataset:
     @staticmethod
     def get_pitch() -> Pitch:
         """Returns a Pitch object corresponding to the StatsBomb Dataset."""
-        return Pitch.from_template("statsbomb")
+        return Pitch.from_template("statsbomb", sport="football")
 
     def _update_data_links_from_files(self):
         """Creates the dictionaries containing data links between competition, season,

--- a/floodlight/io/datasets.py
+++ b/floodlight/io/datasets.py
@@ -124,15 +124,7 @@ class EIGDDataset:
     @staticmethod
     def get_pitch() -> Pitch:
         """Returns a Pitch object corresponding to the EIGD-data."""
-        return Pitch(
-            xlim=(0, 40),
-            ylim=(0, 20),
-            unit="m",
-            boundaries="fixed",
-            length=40,
-            width=20,
-            sport="handball",
-        )
+        return Pitch.from_template("eidg")
 
     def _download_and_extract(self) -> None:
         """Downloads an archive file into temporary storage and

--- a/floodlight/io/datasets.py
+++ b/floodlight/io/datasets.py
@@ -397,8 +397,8 @@ class StatsBombOpenDataset:
 
     @property
     def available_matches(self) -> pd.DataFrame:
-        """Creates and Returns a Table with information for all available matches from
-        the metadata that is downloaded upon instantiation.
+        """Creates and returns a DataFrame with information for all available matches
+        from the metadata that is downloaded upon instantiation.
 
         Returns
         -------
@@ -406,7 +406,7 @@ class StatsBombOpenDataset:
             Table where the rows contain meta information of individual games such as
             ``competition_name``, ``season_name``, and ``match_name`` (in the format
             Home vs. Away), location of the match (``stadium`` and ``country``),
-            ``gender`` of the players (female or male), the ``StatsBomb360_status``  and
+            ``sex`` of the players (female or male), the ``StatsBomb360_status``  and
             the final ``score``.
         """
         summary = pd.DataFrame()
@@ -436,7 +436,7 @@ class StatsBombOpenDataset:
                         "score": f"{info['home_score']}:{info['away_score']}",
                         "stadium": info["stadium"]["name"],
                         "country": info["stadium"]["country"]["name"],
-                        "gender": "f"
+                        "sex": "f"
                         if competition
                         in ["FA Women's Super League", "NWSL", "Women's World Cup"]
                         else "m",
@@ -454,10 +454,11 @@ class StatsBombOpenDataset:
         season_name: str = "2020/2021",
         match_name: str = None,
     ) -> Tuple[Events, Events, Events, Events]:
-        """Get events from one match of the StatsBomb open dataset. If `StatsBomb360
-        data <https://statsbomb.com/articles/soccer/
+        """Get events from one match of the StatsBomb open dataset.
+
+        If `StatsBomb360data <https://statsbomb.com/articles/soccer/
         statsbomb-360-freeze-frame-viewer-a-new-release-in-statsbomb-iq/>`_  are
-        available, they are stored in the  ``qualifier`` column.
+        available, they are stored in the  ``qualifier`` column of the Events object.
         If the files are not contained in the repository's root ``.data`` folder they
         are downloaded to the folder and will be stored until removed by hand.
 
@@ -471,7 +472,7 @@ class StatsBombOpenDataset:
             format YYYY/YYYY and for international cup matches the format YYYY.
             Check Notes for available seasons of every competition.
             Defaults to "2020/2021".
-        match_name
+        match_name: str, optional
             Match name relating to the available matches in the chosen competition and
             season. If equal to None (default), the first available match of the
             given competition and season is chosen.

--- a/floodlight/io/datasets.py
+++ b/floodlight/io/datasets.py
@@ -275,14 +275,15 @@ class StatsBombOpenDataset:
     -----
     The dataset contains result, lineup, and event data for a variety of matches from a
     total of eight different competitions (Women's World Cup, FIFA World Cup, UEFA Euro,
-    Champions League, FA Women's Super League, NWSL, Premier League, and La Liga). The
+    Champions League, FA Women's Super League, NWSL, Premier League, and La Liga). For
+    the Champions League all Finals from 2003/2004 to 2018/2019 are contained. The
     competition with the most matches is La Liga where StatsBomb provides data for every
     one of the 520 matches ever played by Lionel Messi for FC Barcelona. In addition,
     for 51 matches from the UEFA Euro 2020 additional StatsBomb360 data is available.
     This data contains the tracked positions of (some) players at the captured events of
     these matches. As the data is constantly updated, we provide an overview over the
     stats here but refer to the official repository for up-to-date information (last
-    modified 27.04.2022)::
+    modified 06.05.2022)::
 
         number_of_matches = {
             "Champions League": {
@@ -512,7 +513,9 @@ class StatsBombOpenDataset:
                 f"{self._STATSBOMB_FILE_EXT}"
             )
             try:
-                binary_file.write(download_from_url(threesixty_host_url))
+                data = download_from_url(threesixty_host_url)
+                with open(filepath_threesixty, "wb") as binary_file:
+                    binary_file.write(data)
             except HTTPError:
                 filepath_threesixty = None
 

--- a/floodlight/io/statsbomb.py
+++ b/floodlight/io/statsbomb.py
@@ -6,7 +6,6 @@ import json
 import pandas as pd
 
 from floodlight.core.events import Events
-from floodlight.core.pitch import Pitch
 
 
 def _read_competition_file(filepath: Union[str, Path]):
@@ -19,7 +18,7 @@ def _read_competition_file(filepath: Union[str, Path]):
 def read_open_statsbomb_event_data_json(
     filepath_events: Union[str, Path],
     filepath_match: Union[str, Path],
-) -> Tuple[Events, Events, Events, Events, Pitch]:
+) -> Tuple[Events, Events, Events, Events]:
     """Parses a StatsPerform Match Event CSV file and extracts the event data.
 
     This function provides a high-level access to the openly published StatsBomb Match
@@ -36,7 +35,7 @@ def read_open_statsbomb_event_data_json(
 
     Returns
     -------
-    data_objects: Tuple[Events, Events, Events, Events, Pitch]
+    data_objects: Tuple[Events, Events, Events, Events]
         Events- and Pitch-objects for both teams and both halves. The order is
         (home_ht1, home_ht2, away_ht1, away_ht2, pitch).
 
@@ -155,8 +154,7 @@ def read_open_statsbomb_event_data_json(
     away_ht2 = Events(
         events=pd.DataFrame(data=team_event_lists["Away"]["HT2"]),
     )
-    pitch = Pitch.from_template("statsbomb", sport="football")
 
-    data_objects = (home_ht1, home_ht2, away_ht1, away_ht2, pitch)
+    data_objects = (home_ht1, home_ht2, away_ht1, away_ht2)
 
     return data_objects

--- a/floodlight/io/statsbomb.py
+++ b/floodlight/io/statsbomb.py
@@ -152,11 +152,10 @@ def read_open_statsbomb_event_data_json(
         eID = event["type"]["id"]
         tID = event["team"]["id"]
         pID = event["player"]["id"] if "player" in event else None
-        if "type" in event:
+        if "type" in event and event["type"]["name"].lower() in event:
             outcome = (
                 event[event["type"]["name"].lower()]["outcome"]["name"]
-                if event["type"]["name"].lower() in event
-                and "outcome" in event[event["type"]["name"].lower()]
+                if "outcome" in event[event["type"]["name"].lower()]
                 else None
             )
         else:
@@ -180,18 +179,20 @@ def read_open_statsbomb_event_data_json(
         # location
         at_x = event["location"][0] if "location" in event else None
         at_y = event["location"][1] if "location" in event else None
-        to_x = (
-            event[event["type"]["name"].lower()]["end_location"][0]
-            if event["type"]["name"].lower() in event
-            and "end_location" in event[event["type"]["name"].lower()]
-            else None
-        )
-        to_y = (
-            event[event["type"]["name"].lower()]["end_location"][1]
-            if event["type"]["name"].lower() in event
-            and "end_location" in event[event["type"]["name"].lower()]
-            else None
-        )
+        if "type" in event and event["type"]["name"].lower() in event:
+            to_x = (
+                event[event["type"]["name"].lower()]["end_location"][0]
+                if "end_location" in event[event["type"]["name"].lower()]
+                else None
+            )
+            to_y = (
+                event[event["type"]["name"].lower()]["end_location"][1]
+                if "end_location" in event[event["type"]["name"].lower()]
+                else None
+            )
+        else:
+            to_x = None
+            to_y = None
         team_event_lists[team][segment]["at_x"].append(at_x)
         team_event_lists[team][segment]["at_y"].append(at_y)
         team_event_lists[team][segment]["to_x"].append(to_x)

--- a/floodlight/io/statsbomb.py
+++ b/floodlight/io/statsbomb.py
@@ -14,14 +14,17 @@ def read_open_statsbomb_event_data_json(
     filepath_match: Union[str, Path],
     filepath_threesixty: Union[str, Path] = None,
 ) -> Tuple[Events, Events, Events, Events]:
-    """Parses a StatsPerform Match Event json file and extracts the event data.
+    """Parses files for a single match from the StatsBomb open dataset and extracts the
+    event data.
 
     This function provides a high-level access to an events json file from the openly
     published StatsBomb open data and returns Event objects for both teams for the first
     two periods. A StatsBomb360 json file can be passed to the function to include
-    information about the tracked position of (some) players at certain events to the
+    `StatsBomb360 data <https://statsbomb.com/articles/soccer/
+    statsbomb-360-freeze-frame-viewer-a-new-release-in-statsbomb-iq/>`_ to the
     ``qualifier`` column. Requires the parsed files from the dataset to maintain their
-    original names from <https://github.com/statsbomb/open-data>`_.
+    original names from the `official data repository
+    <https://github.com/statsbomb/open-data>`_
 
     Parameters
     ----------
@@ -47,7 +50,9 @@ def read_open_statsbomb_event_data_json(
     StatsBomb's open format of handling provides certain additional event attributes,
     which attach additional information to certain events. As of now, these information
     are parsed as a string in the ``qualifier`` column of the returned DataFrame and can
-    be transformed to a dict of form ``{attribute: value}``.
+    be transformed to a dict of form ``{attribute: value}``. This includes the
+    information about the tracked position of (some) players and the visible area
+    that is included in the StatsBomb360 data.
     """
 
     # load json files into memory

--- a/floodlight/io/statsbomb.py
+++ b/floodlight/io/statsbomb.py
@@ -1,0 +1,162 @@
+from pathlib import Path
+from typing import Tuple, Union
+
+import os
+import json
+import pandas as pd
+
+from floodlight.core.events import Events
+from floodlight.core.pitch import Pitch
+
+
+def _read_competition_file(filepath: Union[str, Path]):
+    with open(filepath, "r") as f:
+        competitions = json.load(f)
+
+    return competitions
+
+
+def read_open_statsbomb_event_data_json(
+    filepath_events: Union[str, Path],
+    filepath_match: Union[str, Path],
+) -> Tuple[Events, Events, Events, Events, Pitch]:
+    """Parses a StatsPerform Match Event CSV file and extracts the event data.
+
+    This function provides a high-level access to the openly published StatsBomb Match
+    Events json file and returns Event objects for both teams.
+
+    Parameters
+    ----------
+    filepath_events: str or pathlib.Path
+        Full path to json File where the Event data in StatsPerform CSV format is
+        saved
+    filepath_match: str or pathlib.Path
+        Full path to json file where information about all matches of a competition are
+         stored.
+
+    Returns
+    -------
+    data_objects: Tuple[Events, Events, Events, Events, Pitch]
+        Events- and Pitch-objects for both teams and both halves. The order is
+        (home_ht1, home_ht2, away_ht1, away_ht2, pitch).
+
+    Notes
+    -----
+    StatsBomb's open format of handling provides certain additional event attributes,
+    which attach additional information to certain events. As of now, these information
+    are parsed as a string in the ``qualifier`` column of the returned DataFrame and can
+    be transformed to a dict of form ``{attribute: value}``.
+    """
+
+    # load json files into memory
+    with open(filepath_match, "r") as f:
+        matchinfo_list = json.load(f)
+    with open(filepath_events, "r") as f:
+        file_event_list = json.load(f)
+
+    # 1. retrieve match info from competition list
+    match_id = int(filepath_events.split(os.path.sep)[-1][:-5])  # from filepath
+    matchinfo = None
+    for info in matchinfo_list:
+        if info["match_id"] == match_id:
+            matchinfo = info
+            break
+
+    # 2. parse match info
+    teams = ["Home", "Away"]
+    tID_link = {
+        int(matchinfo["home_team"]["home_team_id"]): "Home",
+        int(matchinfo["away_team"]["away_team_id"]): "Away",
+    }
+    periods = set([event["period"] for event in file_event_list])
+    segments = [f"HT{period}" for period in periods]
+
+    # 3. parse events
+    # bins
+    columns = [
+        "eID",
+        "gameclock",
+        "pID",
+        "outcome",
+        "timestamp",
+        "minute",
+        "second",
+        "at_x",
+        "at_y",
+        "qualifier",
+    ]
+
+    team_event_lists = {
+        team: {segment: {col: [] for col in columns} for segment in segments}
+        for team in teams
+    }
+
+    # loop
+    for event in file_event_list:
+        # get team and segment information
+        period = event["period"]
+        segment = "HT" + str(period)
+        team = tID_link[event["possession_team"]["id"]]
+
+        # identifier and outcome:
+        eID = event["id"]
+        pID = event["player"] if "player" in event else None
+        if "type" in event:
+            outcome = event["type"]["outcome"] if "outcome" in event["type"] else None
+        else:
+            outcome = None
+        team_event_lists[team][segment]["eID"].append(eID)
+        team_event_lists[team][segment]["pID"].append(pID)
+        team_event_lists[team][segment]["outcome"].append(outcome)
+
+        # relative time
+        timestamp = event["timestamp"]
+        minute = event["minute"]
+        second = event["second"]
+        gameclock = 60 * minute + second  # in seconds
+        team_event_lists[team][segment]["timestamp"].append(timestamp)
+        team_event_lists[team][segment]["minute"].append(minute)
+        team_event_lists[team][segment]["second"].append(second)
+        team_event_lists[team][segment]["gameclock"].append(gameclock)
+
+        # location
+        at_x = event["location"][0] if "location" in event else None
+        at_y = event["location"][1] if "location" in event else None
+        team_event_lists[team][segment]["at_x"].append(at_x)
+        team_event_lists[team][segment]["at_y"].append(at_y)
+
+        # qualifier
+        qual_dict = {}
+        for qualifier in event:
+            if qualifier in [
+                "id",
+                "period",
+                "timestamp",
+                "minute",
+                "second",
+                "location",
+            ]:
+                continue
+
+            qual_value = event[qualifier]
+            qual_dict[qualifier] = qual_value
+        team_event_lists[team][segment]["qualifier"].append(str(qual_dict))
+
+    # assembly
+    home_ht1 = Events(
+        events=pd.DataFrame(data=team_event_lists["Home"]["HT1"]),
+    )
+    home_ht2 = Events(
+        events=pd.DataFrame(data=team_event_lists["Home"]["HT2"]),
+    )
+    away_ht1 = Events(
+        events=pd.DataFrame(data=team_event_lists["Away"]["HT1"]),
+    )
+    away_ht2 = Events(
+        events=pd.DataFrame(data=team_event_lists["Away"]["HT2"]),
+    )
+    pitch = Pitch.from_template("statsbomb", sport="football")
+
+    data_objects = (home_ht1, home_ht2, away_ht1, away_ht2, pitch)
+
+    return data_objects

--- a/floodlight/io/statsbomb.py
+++ b/floodlight/io/statsbomb.py
@@ -20,15 +20,16 @@ def read_open_statsbomb_event_data_json(
     published StatsBomb open data and returns Event objects for both teams for the first
     two periods. A StatsBomb360 json file can be passed to the function to include
     information about the tracked position of (some) players at certain events to the
-    ``qualifier`` column.
+    ``qualifier`` column. Requires the parsed files from the dataset to maintain their
+    original names from <https://github.com/statsbomb/open-data>`_.
 
     Parameters
     ----------
     filepath_events: str or pathlib.Path
         Full path to json file where the Event data is saved.
     filepath_match: str or pathlib.Path
-        Full path to json file where information about all matches of a competition are
-         stored.
+        Full path to json file where information about all matches of a season are
+        stored.
     filepath_threesixty: str or pathlib.Path, optional
         Full path to json file where the StatsBomb360 data in is saved if available. The
         information about the area of the field where player positions are tracked
@@ -149,7 +150,7 @@ def read_open_statsbomb_event_data_json(
         minute = event["minute"]
         second = event["second"]
         millisecond = int(timestamp.split(".")[1])
-        gameclock = 60 * minute + second + millisecond * 0.001  # in seconds
+        gameclock = 60 * minute + second + millisecond * 0.001
         team_event_lists[team][segment]["timestamp"].append(timestamp)
         team_event_lists[team][segment]["minute"].append(minute)
         team_event_lists[team][segment]["second"].append(second)
@@ -182,12 +183,15 @@ def read_open_statsbomb_event_data_json(
         qual_dict["unique_identifier"] = event["id"]
         for qualifier in event:
             if qualifier in [
+                "team",
+                "player",
                 "period",
                 "timestamp",
                 "minute",
                 "second",
                 "location",
                 "id",
+                "type",
             ]:
                 continue
             qual_value = event[qualifier]

--- a/floodlight/io/statsbomb.py
+++ b/floodlight/io/statsbomb.py
@@ -118,15 +118,23 @@ def read_open_statsbomb_event_data_json(
         event_name = event["type"]["name"]
         team_name = event["team"]["name"]
         player_name = event["player"]["name"] if "player" in event else None
-
+        outcome = None
         if "type" in event and event["type"]["name"].lower() in event:
-            outcome = (
+            outcome_name = (
                 event[event["type"]["name"].lower()]["outcome"]["name"]
                 if "outcome" in event[event["type"]["name"].lower()]
-                else None
+                else "None"
             )
-        else:
-            outcome = None
+            if outcome_name in ["Goal", "Won", "Complete", "Success In Play"]:
+                outcome = 1
+            elif outcome_name in [
+                "Incomplete",
+                "Lost In Play",
+                "Saved Off Target",
+                "Off T",
+                "Blocked",
+            ]:
+                outcome = 0
         team_event_lists[team][segment]["mID"].append(mID)
         team_event_lists[team][segment]["eID"].append(eID)
         team_event_lists[team][segment]["tID"].append(tID)

--- a/floodlight/io/statsbomb.py
+++ b/floodlight/io/statsbomb.py
@@ -196,6 +196,7 @@ def read_open_statsbomb_event_data_json(
                 continue
             qual_value = event[qualifier]
             qual_dict[qualifier] = qual_value
+
         if file_threesixty_list is not None:
             threesixty_event = [
                 event


### PR DESCRIPTION
Hi there, 

this PR includes support for the open-data published by StatsBomb earlier this year (https://github.com/statsbomb/open-data). 
The data is accessible over the StatsBombOpenDataset class where it is only downloaded on demand to save time and disk space. 
A code example is provided in the dataset docstring. Maybe a similar example could be useful in the Get Started guide?