### PR TITLE
fix: parser

### DIFF
--- a/floodlight/io/statsperform.py
+++ b/floodlight/io/statsperform.py
@@ -770,7 +770,7 @@ def read_event_data_xml(
                 event_lists[team][segment]["jID"].append(jID)
 
             # relative time
-            gameclock = get_and_convert(event.attrib, "Time", int)
+            gameclock = get_and_convert(event.attrib, "Time", int) / 1000
             minute = np.floor(gameclock / 60)
             second = np.floor(gameclock - minute * 60)
             for team in teams_assigned:


### PR DESCRIPTION
StatsPerform: Fix unit of the gameclock from milliseconds to seconds.

DFL: In more recent versions of the DFL data there is no event "KickOffWhistle" but only the event "KickOff" (which is different from the event "Kickoff" in older versions). Therefore the search for either until one is found.    