### PR TITLE
fix: statsperform pitch templates

### DIFF
--- a/floodlight/core/pitch.py
+++ b/floodlight/core/pitch.py
@@ -152,7 +152,7 @@ class Pitch:
                 width=kwargs.get("width"),
                 sport=kwargs.get("sport"),
             )
-        elif template_name == "statsperform":
+        elif template_name == "statsperform_event":
             if "length" not in kwargs or "width" not in kwargs:
                 raise TypeError(
                     "For an exact StatsPerform Pitch object, "
@@ -165,6 +165,21 @@ class Pitch:
                 xlim=(-x_half, x_half),
                 ylim=(-y_half, y_half),
                 unit="cm",
+                boundaries="flexible",
+                length=kwargs.get("length"),
+                width=kwargs.get("width"),
+            )
+        elif template_name == "statsperform_tracking":
+            if "length" not in kwargs or "width" not in kwargs:
+                raise TypeError(
+                    "For an exact StatsPerform Pitch object, "
+                    "`length` and `width` of the pitch need "
+                    "to be passed as keyworded arguments"
+                )
+            return cls(
+                xlim=(0, kwargs["length"]),
+                ylim=(0, kwargs["width"]),
+                unit="m",
                 boundaries="flexible",
                 length=kwargs.get("length"),
                 width=kwargs.get("width"),
@@ -203,6 +218,8 @@ class Pitch:
                 ylim=(0.0, 80.0),
                 unit="normed",
                 boundaries="flexible",
+                length=120,
+                width=80,
                 sport="football",
             )
         else:

--- a/floodlight/core/pitch.py
+++ b/floodlight/core/pitch.py
@@ -75,8 +75,8 @@ class Pitch:
         ----------
         template_name: str
             The name of the template the pitch should follow. Currently supported are
-            {'dfl', 'eigd', 'opta', 'statsbomb', 'secondspectrum', 'statsperform',
-            'statsperform_open', 'tracab'}.
+            {'dfl', 'eigd', 'opta', 'statsbomb', 'secondspectrum', 'statsperform_event',
+            'statsperform_tracking', 'statsperform_open', 'tracab'}.
         kwargs:
             You may pass optional arguments (`length`, `width`, `sport`) used for class
             instantiation. For some data providers, additional kwargs are needed to
@@ -159,8 +159,8 @@ class Pitch:
                     "`length` and `width` of the pitch need "
                     "to be passed as keyworded arguments"
                 )
-            x_half = round(kwargs["length"] / 2, 3)
-            y_half = round(kwargs["width"] / 2, 3)
+            x_half = round((kwargs["length"] * 100) / 2, 3)
+            y_half = round((kwargs["width"] * 100) / 2, 3)
             return cls(
                 xlim=(-x_half, x_half),
                 ylim=(-y_half, y_half),
@@ -218,8 +218,6 @@ class Pitch:
                 ylim=(0.0, 80.0),
                 unit="normed",
                 boundaries="flexible",
-                length=120,
-                width=80,
                 sport="football",
             )
         else:

--- a/floodlight/io/statsperform.py
+++ b/floodlight/io/statsperform.py
@@ -801,7 +801,7 @@ def read_event_data_xml(
     length = get_and_convert(root.attrib, "FieldLength", int)
     width = get_and_convert(root.attrib, "FieldWidth", int)
     pitch = Pitch.from_template(
-        "statsperform",
+        "statsperform_event",
         length=length,
         width=width,
         sport="football",

--- a/floodlight/io/statsperform.py
+++ b/floodlight/io/statsperform.py
@@ -798,8 +798,8 @@ def read_event_data_xml(
                 event_lists[team][segment]["qualifier"].append(str(qual_dict))
 
     # create pitch
-    length = get_and_convert(root.attrib, "FieldLength", int)
-    width = get_and_convert(root.attrib, "FieldWidth", int)
+    length = get_and_convert(root.attrib, "FieldLength", int) / 100
+    width = get_and_convert(root.attrib, "FieldWidth", int) / 100
     pitch = Pitch.from_template(
         "statsperform_event",
         length=length,

--- a/tests/test_core/test_pitch.py
+++ b/tests/test_core/test_pitch.py
@@ -49,7 +49,7 @@ def test_template_statsperform_open() -> None:
 @pytest.mark.unit
 def test_template_statsperform_event() -> None:
     # Arrange
-    pitch = Pitch.from_template("statsperform_event", length=11000, width=6800)
+    pitch = Pitch.from_template("statsperform_event", length=110, width=68)
 
     # Assert
     with pytest.raises(TypeError):

--- a/tests/test_core/test_pitch.py
+++ b/tests/test_core/test_pitch.py
@@ -47,16 +47,30 @@ def test_template_statsperform_open() -> None:
 
 
 @pytest.mark.unit
-def test_template_statsperform() -> None:
+def test_template_statsperform_event() -> None:
     # Arrange
-    pitch = Pitch.from_template("statsperform", length=11000, width=6800)
+    pitch = Pitch.from_template("statsperform_event", length=11000, width=6800)
 
     # Assert
     with pytest.raises(TypeError):
-        Pitch.from_template("statsperform")
+        Pitch.from_template("statsperform_event")
     assert pitch.xlim == (-5500, 5500)
     assert pitch.ylim == (-3400, 3400)
     assert pitch.unit == "cm"
+    assert pitch.boundaries == "flexible"
+
+
+@pytest.mark.unit
+def test_template_statsperform_tracking() -> None:
+    # Arrange
+    pitch = Pitch.from_template("statsperform_tracking", length=110, width=68)
+
+    # Assert
+    with pytest.raises(TypeError):
+        Pitch.from_template("statsperform_tracking")
+    assert pitch.xlim == (0, 110)
+    assert pitch.ylim == (0, 68)
+    assert pitch.unit == "m"
     assert pitch.boundaries == "flexible"
 
 


### PR DESCRIPTION
Create two seperate classes for Statsperform Pitch: One for event and one for tracking data.
Quick fix to add width and length to StatsBomb Pitch.