### PR TITLE
fix: pass difference argument to axis-specific differentiation and fix prepend

### DIFF
--- a/floodlight/models/kinematics.py
+++ b/floodlight/models/kinematics.py
@@ -233,7 +233,9 @@ class VelocityModel(BaseModel):
         distance_model.fit(xy, difference=difference, axis=axis)
         distance_euclidean = distance_model.distance_covered()
 
-        velocity = distance_euclidean.property * distance_euclidean.framerate
+        velocity = np.multiply(
+            distance_euclidean.property, distance_euclidean.framerate
+        )
 
         self._velocity_ = PlayerProperty(
             property=velocity, name="velocity", framerate=xy.framerate
@@ -334,15 +336,17 @@ class AccelerationModel(BaseModel):
         velocity = velocity_model.velocity()
 
         if difference == "central":
-            acceleration = np.gradient(velocity.property, axis=0) * velocity.framerate
+            acceleration = np.multiply(
+                np.gradient(velocity.property, axis=0), velocity.framerate
+            )
         else:
-            acceleration = (
+            acceleration = np.multiply(
                 np.diff(
                     velocity.property,
                     axis=0,
                     prepend=velocity.property[0].reshape(1, -1),
-                )
-                * velocity.framerate
+                ),
+                velocity.framerate,
             )
 
         self._acceleration_ = PlayerProperty(

--- a/floodlight/models/kinematics.py
+++ b/floodlight/models/kinematics.py
@@ -340,7 +340,7 @@ class AccelerationModel(BaseModel):
                 np.diff(
                     velocity.property,
                     axis=0,
-                    append=velocity.property[0].reshape(1, -1),
+                    prepend=velocity.property[0].reshape(1, -1),
                 )
                 * velocity.framerate
             )

--- a/floodlight/models/kinematics.py
+++ b/floodlight/models/kinematics.py
@@ -87,7 +87,7 @@ covered`
             if difference == "central":
                 differences_xy = np.gradient(xy.xy, axis=0)
             elif difference == "backward":
-                differences_xy = np.diff(xy.xy, axis=0, prepend=0)
+                differences_xy = np.diff(xy.xy, axis=0, prepend=xy.xy[0].reshape(1, -1))
             else:
                 raise ValueError(
                     f"Expected axis to be one of (None, 'x', 'y'), got {axis}."
@@ -97,9 +97,19 @@ covered`
                 differences_xy[:, 1::2],
             )
         elif axis == "x":
-            distance_euclidean = np.gradient(xy.x, axis=0)
+            if difference == "central":
+                distance_euclidean = np.gradient(xy.x, axis=0)
+            elif difference == "backward":
+                distance_euclidean = np.diff(
+                    xy.x, axis=0, prepend=xy.x[0].reshape(1, -1)
+                )
         elif axis == "y":
-            distance_euclidean = np.gradient(xy.y, axis=0)
+            if difference == "central":
+                distance_euclidean = np.gradient(xy.y, axis=0)
+            if difference == "backward":
+                distance_euclidean = np.diff(
+                    xy.y, axis=0, prepend=xy.y[0].reshape(1, -1)
+                )
         else:
             raise ValueError(
                 f"Expected axis to be one of (None, 'x', 'y'), got {axis}."
@@ -327,7 +337,12 @@ class AccelerationModel(BaseModel):
             acceleration = np.gradient(velocity.property, axis=0) * velocity.framerate
         else:
             acceleration = (
-                np.diff(velocity.property, axis=0, append=0) * velocity.framerate
+                np.diff(
+                    velocity.property,
+                    axis=0,
+                    append=velocity.property[0].reshape(1, -1),
+                )
+                * velocity.framerate
             )
 
         self._acceleration_ = PlayerProperty(

--- a/tests/test_models/test_kinematics.py
+++ b/tests/test_models/test_kinematics.py
@@ -168,7 +168,7 @@ def test_acceleration_model_difference_backward(example_xy_object_kinematics) ->
     # Assert
     assert np.array_equal(
         np.round(acceleration, 3),
-        np.array(((400, np.NaN), (165.685, np.NaN), (-565.685, np.NaN))),
+        np.array(((0, 0), (400, np.NaN), (165.685, np.NaN))),
         equal_nan=True,
     )
 

--- a/tests/test_models/test_kinematics.py
+++ b/tests/test_models/test_kinematics.py
@@ -42,7 +42,7 @@ def test_distance_model_fit_difference_backward(example_xy_object_kinematics) ->
     # Assert
     assert np.array_equal(
         np.round(distance_covered, 3),
-        np.array(((0, 1.414), (1, np.NaN), (1.414, np.NaN))),
+        np.array(((0, 0), (1, np.NaN), (1.414, np.NaN))),
         equal_nan=True,
     )
 
@@ -114,7 +114,7 @@ def test_velocity_model_fit_difference_backward(example_xy_object_kinematics) ->
     # Assert
     assert np.array_equal(
         np.round(velocity, 3),
-        np.array(((0, 28.284), (20, np.NaN), (28.284, np.NaN))),
+        np.array(((0, 0), (20, np.NaN), (28.284, np.NaN))),
         equal_nan=True,
     )
 


### PR DESCRIPTION
Short fix for passing through the `difference` argument when `axis` is 'x'/ 'y' and fixed `prepend` argument in np.diff()