### PR TITLE
fix: MetabolicPower framerate bug

### DIFF
--- a/floodlight/models/kinetics.py
+++ b/floodlight/models/kinetics.py
@@ -393,7 +393,7 @@ equivalent_distance`
         # Calculate energy cost of locomotion
         ecl = MetabolicPowerModel._calc_ecl(es, vel, em, eccr)
         # Calculate metabolic power as product of ecl and velocity (m/s)
-        metp = ecl * vel / framerate
+        metp = ecl * vel
 
         return metp
 
@@ -476,7 +476,10 @@ equivalent_distance`
             frames and N is the number of players. The columns contain the cumulative
             metabolic power calculated by numpy.nancumsum() over axis=0.
         """
-        cum_metp = np.nancumsum(self._metabolic_power_.property, axis=0)
+        cum_metp = (
+            np.nancumsum(self._metabolic_power_.property, axis=0)
+            / self._metabolic_power_.framerate
+        )
         cumulative_metabolic_power = PlayerProperty(
             property=cum_metp,
             name="cumulative_metabolic_power",
@@ -532,7 +535,10 @@ equivalent_distance`
             frames and N is the number of players. The columns contain the cumulative
             equivalent distance calculated by numpy.nancumsum() over axis=0.
         """
-        cum_metp = np.nancumsum(self._metabolic_power_.property, axis=0)
+        cum_metp = (
+            np.nancumsum(self._metabolic_power_.property, axis=0)
+            / self._metabolic_power_.framerate
+        )
         cum_eqdist = cum_metp / eccr
 
         cumulative_equivalent_distance = PlayerProperty(

--- a/floodlight/models/kinetics.py
+++ b/floodlight/models/kinetics.py
@@ -476,9 +476,9 @@ equivalent_distance`
             frames and N is the number of players. The columns contain the cumulative
             metabolic power calculated by numpy.nancumsum() over axis=0.
         """
-        cum_metp = (
-            np.nancumsum(self._metabolic_power_.property, axis=0)
-            / self._metabolic_power_.framerate
+        cum_metp = np.divide(
+            np.nancumsum(self._metabolic_power_.property, axis=0),
+            self._metabolic_power_.framerate
         )
         cumulative_metabolic_power = PlayerProperty(
             property=cum_metp,
@@ -535,9 +535,9 @@ equivalent_distance`
             frames and N is the number of players. The columns contain the cumulative
             equivalent distance calculated by numpy.nancumsum() over axis=0.
         """
-        cum_metp = (
-            np.nancumsum(self._metabolic_power_.property, axis=0)
-            / self._metabolic_power_.framerate
+        cum_metp = np.divide(
+            np.nancumsum(self._metabolic_power_.property, axis=0),
+            self._metabolic_power_.framerate
         )
         cum_eqdist = cum_metp / eccr
 

--- a/tests/test_models/test_kinetics.py
+++ b/tests/test_models/test_kinetics.py
@@ -156,7 +156,7 @@ def test_calc_metabolic_power(
     # Assert
     assert np.array_equal(
         np.round(metabolic_power, 3),
-        np.array(((0.101, 0.045), (0.251, 2.427), (2.602, 0.347))),
+        np.array(((2.020, 0.896), (5.011, 48.540), (52.038, 6.931))),
     )
 
 
@@ -173,7 +173,7 @@ def test_metabolic_power(example_pitch_dfl, example_xy_object_kinetics) -> None:
     # Assert
     assert np.array_equal(
         np.round(metabolic_power, 3),
-        np.array(((0.459, 0.223), (0.465, 0.249), (0.472, 0.278))),
+        np.array(((9.177, 4.452), (9.306, 4.988), (9.439, 5.570))),
     )
 
 
@@ -209,7 +209,7 @@ def test_equivalent_distance(example_pitch_dfl, example_xy_object_kinetics) -> N
     # Assert
     assert np.array_equal(
         np.round(equivalent_distance, 3),
-        np.array(((0.127, 0.062), (0.129, 0.069), (0.131, 0.077))),
+        np.array(((2.549, 1.237), (2.585, 1.386), (2.622, 1.547))),
     )
 
 


### PR DESCRIPTION
Hi, congratulations on the published paper! This fixes a bug in the `MetabolicPowerModel`. The division by the frame rate was done during the calculation of Metabolic Power, which is wrong, as the Velocity already accounts for the frame rate. Instead, it has to be done when integrating the Metabolic Power to Work. This impacts the calculation of Metabolic Power but **not** of Metabolic Work.