### PR TITLE
ci: flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     hooks:
     -   id: black
         language_version: python3
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
     -   id: flake8


### PR DESCRIPTION
Update the location of Flake8 in the pre-commit configuration, which was moved from Github to Gitlab (see https://github.com/facebookresearch/habitat-lab/pull/1002). 