### PR TITLE
feat: integrate teamsheet logic to statsbomb parser

### DIFF
--- a/docs/source/guides/tutorial_matchsheets.rst
+++ b/docs/source/guides/tutorial_matchsheets.rst
@@ -16,7 +16,14 @@ First we need some data to work with. The open StatsBomb dataset contains (among
 
     # load a match from the UEFA Euro 2020
     dataset = StatsBombOpenDataset()
-    home_ht1, home_ht2, away_ht1, away_ht2 = dataset.get("UEFA Euro", "2020", "Croatia vs. Spain")
+    (
+        home_ht1,
+        home_ht2,
+        away_ht1,
+        away_ht2,
+        home_teamsheet,
+        away_teamsheet,
+    ) = dataset.get("UEFA Euro", "2020", "Croatia vs. Spain")
     pitch = dataset.get_pitch()
 
 The variables ``home_ht1``, ``home_ht2``, ``away_ht1``, and ``away_ht2`` are Events objects containing the events of the teams during the first and second half. These will be used to create the match sheets. The ``pitch`` variable is a Pitch object that contains information regarding the pitch specification and coordinate system our data live in.

--- a/floodlight/io/datasets.py
+++ b/floodlight/io/datasets.py
@@ -8,8 +8,9 @@ import numpy as np
 import pandas as pd
 
 from floodlight.io.utils import extract_zip, download_from_url
-from floodlight.io.statsbomb import read_open_event_data_json
+from floodlight.io.statsbomb import read_open_statsperform_event_data_json
 from floodlight import XY, Pitch, Events, Code
+from floodlight.core.teamsheet import Teamsheet
 from floodlight.settings import DATA_DIR
 
 
@@ -493,7 +494,7 @@ class StatsBombOpenDataset:
         competition_name: str = "La Liga",
         season_name: str = "2020/2021",
         match_name: str = None,
-    ) -> Tuple[Events, Events, Events, Events]:
+    ) -> Tuple[Events, Events, Events, Events, Teamsheet, Teamsheet]:
         """Get events from one match of the StatsBomb open dataset.
 
         If `StatsBomb360data <https://statsbomb.com/articles/soccer/
@@ -519,9 +520,9 @@ class StatsBombOpenDataset:
 
         Returns
         -------
-        data_objects: Tuple[Events, Events, Events, Events]
-            Returns four Events objects of the form (events_home_ht1, events_home_ht2,
-            events_away_ht1, events_away_ht2) for the requested sample.
+        data_objects: Tuple[Events, Events, Events, Events, Teamsheet, Teamsheet]
+            Events-, and Teamsheet objects for both teams and both halves. The order
+            is (home_ht1, home_ht2, away_ht1, away_ht2, home_teamsheet, away_teamsheet).
         """
         # get identifiers from links
         cID = self._links_competition_to_cID[competition_name]
@@ -577,12 +578,28 @@ class StatsBombOpenDataset:
                 filepath_threesixty = None
 
         # read events from file
-        (home_ht1, home_ht2, away_ht1, away_ht2,) = read_open_event_data_json(
+        (
+            home_ht1,
+            home_ht2,
+            away_ht1,
+            away_ht2,
+            home_teamsheet,
+            away_teamsheet,
+        ) = read_open_statsperform_event_data_json(
             filepath_events, filepath_matches, filepath_threesixty
         )
-        event_objects = (home_ht1, home_ht2, away_ht1, away_ht2)
 
-        return event_objects
+        # assembly
+        data_objects = (
+            home_ht1,
+            home_ht2,
+            away_ht1,
+            away_ht2,
+            home_teamsheet,
+            away_teamsheet,
+        )
+
+        return data_objects
 
     @staticmethod
     def get_pitch() -> Pitch:

--- a/floodlight/io/datasets.py
+++ b/floodlight/io/datasets.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 
 from floodlight.io.utils import extract_zip, download_from_url
-from floodlight.io.statsbomb import read_open_statsbomb_event_data_json
+from floodlight.io.statsbomb import read_open_event_data_json
 from floodlight import XY, Pitch, Events, Code
 from floodlight.settings import DATA_DIR
 
@@ -577,7 +577,7 @@ class StatsBombOpenDataset:
                 filepath_threesixty = None
 
         # read events from file
-        (home_ht1, home_ht2, away_ht1, away_ht2,) = read_open_statsbomb_event_data_json(
+        (home_ht1, home_ht2, away_ht1, away_ht2,) = read_open_event_data_json(
             filepath_events, filepath_matches, filepath_threesixty
         )
         event_objects = (home_ht1, home_ht2, away_ht1, away_ht2)

--- a/floodlight/io/statsbomb.py
+++ b/floodlight/io/statsbomb.py
@@ -28,8 +28,7 @@ def read_teamsheets_from_open_statsperform_files(
     Returns
     -------
     teamsheets: Dict[str, Teamsheet]
-        Two class instances for the home team at the first position and the away
-        teams at the second position.
+        Dictionary with teamsheets for the home team and the away team.
     """
     # load json file into memory
     with open(filepath_match, "r", encoding="utf8") as f:

--- a/floodlight/io/statsbomb.py
+++ b/floodlight/io/statsbomb.py
@@ -45,7 +45,7 @@ def read_teamsheets_from_open_statsperform_files(
             matchinfo = info
             break
 
-    # initialize matchsheets
+    # initialize teamsheets
     teamsheets = {
         "Home": pd.DataFrame(
             columns=["player", "position", "team", "jID", "pID", "tID"]

--- a/floodlight/io/statsbomb.py
+++ b/floodlight/io/statsbomb.py
@@ -9,7 +9,7 @@ import pandas as pd
 from floodlight.core.events import Events
 
 
-def read_open_statsbomb_event_data_json(
+def read_open_event_data_json(
     filepath_events: Union[str, Path],
     filepath_match: Union[str, Path],
     filepath_threesixty: Union[str, Path] = None,


### PR DESCRIPTION
Integrate the logic of Teamsheet objects in the StatsBomb parser. Add a seperate function to create teamsheet objects from the StatsBomb files. Teamsheets are used to create links between teams and team IDs and are returned in the main parsing function. The changes in the return are also integrated to the dataset and tutorial files.