### PR TITLE
test: fix broken test

### DIFF
--- a/tests/test_core/test_events.py
+++ b/tests/test_core/test_events.py
@@ -94,9 +94,10 @@ def test_protected_missing(
 
     # Act
     missing_protected_columns = data.protected_missing
+    total_num_protected = len(protected_columns)
 
     # Assert
-    assert len(missing_protected_columns) == 15
+    assert len(missing_protected_columns) == total_num_protected - 2
 
 
 @pytest.mark.unit


### PR DESCRIPTION
The number protected columns was previously hardcoded, leading to a failed test when changing the protected_columns variable. Change to a flexible variable in the test.   