### PR TITLE
fix: docstrings of Statsperform URL functions 

### DIFF
--- a/floodlight/io/datasets.py
+++ b/floodlight/io/datasets.py
@@ -479,8 +479,12 @@ class StatsBombOpenDataset:
                         f"vs. "
                         f"{info['away_team']['away_team_name']}",
                         "score": f"{info['home_score']}:{info['away_score']}",
-                        "stadium": info["stadium"]["name"],
-                        "country": info["stadium"]["country"]["name"],
+                        "stadium": info["stadium"]["name"]
+                        if "stadium" in info
+                        else None,
+                        "country": info["stadium"]["country"]["name"]
+                        if "stadium" in info
+                        else None,
                         "sex": "f"
                         if competition
                         in ["FA Women's Super League", "NWSL", "Women's World Cup"]

--- a/floodlight/io/statsperform.py
+++ b/floodlight/io/statsperform.py
@@ -1237,7 +1237,7 @@ def read_position_data_from_url(
     url: str,
     teamsheet_home: Teamsheet = None,
     teamsheet_away: Teamsheet = None,
-) -> Tuple[Dict[str, Dict[str, XY]], Dict[str, Teamsheet]]:
+) -> Tuple[Dict[int, Dict[str, XY]], Dict[int, Teamsheet]]:
     """Reads a URL from the StatsPerform API (StatsEdgeViewer) containing a position
     data TXT file and extracts position data and teamsheets.
 
@@ -1260,14 +1260,14 @@ def read_position_data_from_url(
 
     Returns
     -------
-    data_objects: Tuple[Dict[str, Dict[str, XY]], Dict[str, Teamsheet]]
+    data_objects: Tuple[Dict[int, Dict[str, XY]], Dict[int, Teamsheet]]
         Tuple of (nested) floodlight core objects with shape (xy_objects,
         teamsheets).
 
         ``xy_objects`` is a nested dictionary containing ``XY`` objects for each team
         and segment of the form ``xy_objects[segment][team] = XY``. For a typical
         league match with two halves and teams this dictionary looks like:
-        ``{'HT1': {'Home': XY, 'Away': XY}, 'HT2': {'Home': XY, 'Away': XY}}``.
+        ``{1: {'Home': XY, 'Away': XY}, 2: {'Home': XY, 'Away': XY}}``.
 
         ``teamsheets`` is a dictionary containing ``Teamsheet`` objects for each team
         of the form ``teamsheets[team] = Teamsheet``.


### PR DESCRIPTION
Fix the datatype of segment in the documentation of the URL function such that it is the same than the read_from_txt function.