### PR TITLE
fix: nanargmin with all nan slice

### DIFF
--- a/floodlight/models/space.py
+++ b/floodlight/models/space.py
@@ -200,7 +200,11 @@ class DiscreteVoronoiModel(BaseModel):
 
             # calculate pairwise distances and determine closest player
             pairwise_distances = cdist(mesh_points, player_points)
-            closest_player_index = np.nanargmin(pairwise_distances, axis=1)
+            closest_player_index = np.where(
+                np.isnan(pairwise_distances).all(axis=1),
+                np.NaN,
+                np.nanargmin(pairwise_distances, axis=1)
+            )
             self._cell_controls_[t] = closest_player_index.reshape(self._meshx_.shape)
 
     def fit(self, xy1: XY, xy2: XY):

--- a/floodlight/models/space.py
+++ b/floodlight/models/space.py
@@ -192,19 +192,26 @@ class DiscreteVoronoiModel(BaseModel):
             np.nan,
         )
 
+        # stack and reshape mesh coordinates to (M x 2) array
+        mesh_points = np.stack((self._meshx_, self._meshy_), axis=2).reshape(-1, 2)
+
         # loop
         for t in range(T):
-            # stack and reshape player and mesh coordinates to (M x 2) arrays
+            # stack and reshape player coordinates to (M x 2) array
             player_points = np.hstack((xy1.frame(t), xy2.frame(t))).reshape(-1, 2)
-            mesh_points = np.stack((self._meshx_, self._meshy_), axis=2).reshape(-1, 2)
 
             # calculate pairwise distances and determine closest player
             pairwise_distances = cdist(mesh_points, player_points)
-            closest_player_index = np.where(
-                np.isnan(pairwise_distances).all(axis=1),
-                np.NaN,
-                np.nanargmin(pairwise_distances, axis=1)
-            )
+
+            # identify valid segments without all-NaN slices
+            all_nan_mask = np.isnan(pairwise_distances).all(axis=1)
+            valid_mask = ~all_nan_mask
+
+            # Init closest player index array
+            closest_player_index = np.full(pairwise_distances.shape[0], np.NaN)
+
+            if np.any(valid_mask):
+                closest_player_index = np.nanargmin(pairwise_distances, axis=1)
             self._cell_controls_[t] = closest_player_index.reshape(self._meshx_.shape)
 
     def fit(self, xy1: XY, xy2: XY):
@@ -356,20 +363,26 @@ class DiscreteVoronoiModel(BaseModel):
 
         .. image:: ../../_img/sample_dvm_plot_hex.png
         """
-        # get ax
-        ax = ax or plt.subplots()[1]
 
-        # get colors and construct team color vector
-        team_color1, team_color2 = team_colors
-        color_vector = [team_color1] * self._N1_ + [team_color2] * self._N2_
+        # check if t refers to an all-nan slice in the cell controlls
+        if np.isnan(self._cell_controls_[t]).all():
+            pass
+        else:
 
-        # call plot by mesh type
-        if self._mesh_type == "square":
-            ax = self._plot_square(t, color_vector, ax=ax, **kwargs)
-        elif self._mesh_type == "hexagonal":
-            ax = self._plot_hexagonal(t, color_vector, ax=ax, **kwargs)
+            # get ax
+            ax = ax or plt.subplots()[1]
 
-        return ax
+            # get colors and construct team color vector
+            team_color1, team_color2 = team_colors
+            color_vector = [team_color1] * self._N1_ + [team_color2] * self._N2_
+
+            # call plot by mesh type
+            if self._mesh_type == "square":
+                ax = self._plot_square(t, color_vector, ax=ax, **kwargs)
+            elif self._mesh_type == "hexagonal":
+                ax = self._plot_hexagonal(t, color_vector, ax=ax, **kwargs)
+
+            return ax
 
     def _plot_square(
         self,


### PR DESCRIPTION
This fixes an issue in the `DiscreteVoronoiModel`. The model crashes when frame are all NaN because of the `np.nanargmin()` function. This is because of type stability of the return of that function as its supposed to return integers. See https://github.com/pydata/xarray/issues/4481 and https://github.com/pydata/xarray/issues/3884. 
One easy fix for this would be to apply the `np.nanargmin()` only to slices that are not all NaN using `np.where()`. However, masking the hole array before the loop and catching the all NaN slices early might be a more elegant and better performing option.