### PR TITLE
Fix: black hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     -   id: check-yaml
     -   id: check-added-large-files
 -   repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 22.3.0
     hooks:
     -   id: black
         language_version: python3


### PR DESCRIPTION
This PR fixes the import error described [here](https://stackoverflow.com/questions/71673404/importerror-cannot-import-name-unicodefun-from-click) by upgrading the black version in the `.pre-commit-config.yaml`. In addition it may be worth updating the dev-dependencies in the pyproject.toml as discussed in the thread. However, this hat no impact on my tests.