### PR TITLE
feat: add Taki-Hasegawa model to SpaceControlModel

### DIFF
--- a/docs/source/modules/models/models.rst
+++ b/docs/source/modules/models/models.rst
@@ -25,7 +25,7 @@ Collection of data models grouped by category. Each submodule contains model cla
    kinematics.AccelerationModel
    geometry.CentroidModel
    kinetics.MetabolicPowerModel
-   space.DiscreteVoronoiModel
+   space.SpaceControlModel
 
 
 For quick reference, the following computations are available after calling the respective model's ``.fit(...)``-method
@@ -70,7 +70,7 @@ For quick reference, the following computations are available after calling the 
 .. autosummary::
    :nosignatures:
 
-   DiscreteVoronoiModel.player_controls
-   DiscreteVoronoiModel.team_controls
-   DiscreteVoronoiModel.plot
-   DiscreteVoronoiModel.plot_mesh
+   SpaceControlModel.player_controls
+   SpaceControlModel.team_controls
+   SpaceControlModel.plot
+   SpaceControlModel.plot_mesh

--- a/floodlight/models/space.py
+++ b/floodlight/models/space.py
@@ -11,7 +11,7 @@ from floodlight.models.base import BaseModel, requires_fit
 from floodlight.models.kinematics import VelocityVectorModel
 
 
-class DiscreteVoronoiModel(BaseModel):
+class SpaceControlModel(BaseModel):
     """Calculates discretized versions of the Voronoi tessellation commonly used to
     assess space control.
 
@@ -77,13 +77,13 @@ class DiscreteVoronoiModel(BaseModel):
     --------
     >>> import numpy as np
     >>> from floodlight import XY, Pitch
-    >>> from floodlight.models.space import DiscreteVoronoiModel
+    >>> from floodlight.models.space import SpaceControlModel
 
     >>> # create data and fit model
     >>> xy1 = XY(np.array(((10, 10, 20, 80, 30, 40), (10, 10, np.nan, np.nan, 35, 35))))
     >>> xy2 = XY(np.array(((90, 90, 80, 20, 75, 80), (90, 90, 75, 25, 80, 70))))
     >>> pitch = Pitch.from_template("opta", length=105, width=68)
-    >>> dvm = DiscreteVoronoiModel(pitch)
+    >>> dvm = SpaceControlModel(pitch)
     >>> dvm.fit(xy1, xy2)
 
     >>> # print player controls [%] for first team
@@ -488,7 +488,7 @@ class DiscreteVoronoiModel(BaseModel):
 
         Examples
         --------
-        Given a DiscreteVoronoiModel that has already been fitted:
+        Given a SpaceControlModel that has already been fitted:
 
         >>> # fitted_dvm_model has square mesh
         >>> ax = pitch.plot(color_scheme="bw")
@@ -592,7 +592,7 @@ class DiscreteVoronoiModel(BaseModel):
 
         Examples
         --------
-        Given a DiscreteVoronoiModel that has already been fitted:
+        Given a SpaceControlModel that has already been fitted:
 
         >>> ax = pitch.plot(color_scheme="bw")
         >>> fitted_dvm_model.plot_mesh(ax=ax)

--- a/floodlight/models/space.py
+++ b/floodlight/models/space.py
@@ -293,6 +293,10 @@ class SpaceControlModel(BaseModel):
             Player spatiotemporal data of the second team.
         """
 
+        # Check if both inputs are valid XY objects
+        if not isinstance(xy1, XY) or not isinstance(xy2, XY):
+            raise TypeError("Both inputs must be valid XY objects.")
+
         # check if xy1 and xy2 are valid
         if len(xy1) != len(xy2):
             raise ValueError("XY objects must have the same number of frames.")
@@ -300,7 +304,6 @@ class SpaceControlModel(BaseModel):
         # check for out-of-bounds player positions
         mask1 = self.check_positions_within_pitch(xy1, self._pitch)
         mask2 = self.check_positions_within_pitch(xy2, self._pitch)
-
         if not np.all(mask1):
             raise ValueError(
                 "Some players in xy1 are positioned outside the pitch bounds."

--- a/floodlight/models/space.py
+++ b/floodlight/models/space.py
@@ -16,9 +16,14 @@ class SpaceControlModel(BaseModel):
     Computes space control on a discretized pitch using different underlying models.
 
     The SpaceControlModel allows for different definitions of control:
-    - Euclidean Voronoi tessellation: Each mesh point is assigned to the nearest player.
-    - Taki-Hasegawa motion model: Each mesh point is assigned to the player who can
-      reach it fastest, considering initial velocity and maximum acceleration.
+
+    - **Euclidean Voronoi tessellation**: Each mesh point is assigned to the
+      nearest player.
+
+    - **Taki-Hasegawa motion model**: Each mesh point is assigned to the player
+      who can reach it fastest, considering initial velocity and maximum
+      acceleration.
+
 
     Upon instantiation, this model creates a mesh grid that spans the entire pitch with
     a fixed number of mesh points. When calling the :func:`~SpaceControlModel.fit`
@@ -78,17 +83,15 @@ class SpaceControlModel(BaseModel):
 
     References
     ----------
-        .. [1] `Taki, T., & Hasegawa, J. (2000). Visualization of dominant region in
-            team games and its application to teamwork analysis. Proceedings Computer
-            Graphics International 2000, 227–235.
-            <https://ieeexplore.ieee.org/document/852338>`_
-        .. [2] `Fonseca, S., Milho, J., Travassos, B., & Araújo, D. (2012). Spatial
-            dynamics of team sports exposed by Voronoi diagrams. Human Movement
-            Science, 31(6), 1652–1659. <https://doi.org/10.1016/j.humov.2012.04.006>`_
-        .. [3] `Rein, R., Raabe, D., & Memmert, D. (2017). “Which pass is better?”
-            Novel approaches to assess passing effectiveness in elite soccer. Human
-            Movement Science, 55, 172–181.
-            <https://doi.org/10.1016/j.humov.2017.07.010>`_
+    .. [1] Taki, T., & Hasegawa, J. (2000). Visualization of dominant region in team
+           games and its application to teamwork analysis. Proc. Computer Graphics
+           International, 227–235. https://ieeexplore.ieee.org/document/852338
+    .. [2] Fonseca, S., Milho, J., Travassos, B., & Araújo, D. (2012). Spatial dynamics
+           of team sports exposed by Voronoi diagrams. Human Movement Science, 31(6),
+           1652–1659. https://doi.org/10.1016/j.humov.2012.04.006
+    .. [3] Rein, R., Raabe, D., & Memmert, D. (2017). “Which pass is better?” Novel
+           approaches to assess passing effectiveness in elite soccer. Human Movement
+           Science, 55, 172–181. https://doi.org/10.1016/j.humov.2017.07.010
 
     Examples
     --------

--- a/tests/test_models/conftest.py
+++ b/tests/test_models/conftest.py
@@ -90,3 +90,171 @@ def example_xy_objects_space_control() -> Tuple[XY, XY]:
     )
 
     return xy1, xy2
+
+
+@pytest.fixture()
+def example_xy_objects_space_control_static_players() -> Tuple[XY, XY]:
+    xy1 = XY(
+        xy=np.array(
+            (
+                (-45, 0),
+                (-45, 0),
+            )
+        ),
+        framerate=20,
+    )
+    xy2 = XY(
+        xy=np.array(
+            (
+                (45, 0),
+                (45, 0),
+            )
+        ),
+        framerate=20,
+    )
+
+    return xy1, xy2
+
+
+@pytest.fixture()
+def example_xy_objects_space_control_player2_runs_at_player1() -> Tuple[XY, XY]:
+    xy1 = XY(
+        xy=np.array(
+            (
+                (-45, 0),
+                (-45, 0),
+            )
+        ),
+        framerate=20,
+    )
+    xy2 = XY(
+        xy=np.array(
+            (
+                (45, 0),
+                (44.6, 0),
+            )
+        ),
+        framerate=20,
+    )
+
+    return xy1, xy2
+
+
+@pytest.fixture()
+def example_xy_objects_space_control_players_run_towards_each_other() -> Tuple[XY, XY]:
+    xy1 = XY(
+        xy=np.array(
+            (
+                (-10, 0),
+                (-9.8, 0),
+            )
+        ),
+        framerate=20,
+    )
+    xy2 = XY(
+        xy=np.array(
+            (
+                (10, 0),
+                (9.8, 0),
+            )
+        ),
+        framerate=20,
+    )
+
+    return xy1, xy2
+
+
+@pytest.fixture()
+def example_xy_objects_space_control_players_run_same_direction() -> Tuple[XY, XY]:
+    xy1 = XY(
+        xy=np.array(
+            (
+                (-10, 0),
+                (-10.2, 0),
+            )
+        ),
+        framerate=20,
+    )
+    xy2 = XY(
+        xy=np.array(
+            (
+                (10, 0),
+                (9.8, 0),
+            )
+        ),
+        framerate=20,
+    )
+
+    return xy1, xy2
+
+
+@pytest.fixture()
+def example_xy_objects_space_control_identical_positions() -> Tuple[XY, XY]:
+    xy1 = XY(
+        xy=np.array(
+            (
+                (0, 0),
+                (0, 0),
+            )
+        ),
+        framerate=20,
+    )
+    xy2 = XY(
+        xy=np.array(
+            (
+                (0, 0),
+                (0, 0),
+            )
+        ),
+        framerate=20,
+    )
+
+    return xy1, xy2
+
+
+@pytest.fixture()
+def example_xy_objects_nan_vertical() -> Tuple[XY, XY]:
+    xy1 = XY(
+        xy=np.array(
+            (
+                (0, np.nan),
+                (0, np.nan),
+            )
+        ),
+        framerate=20,
+    )
+    xy2 = XY(
+        xy=np.array(
+            (
+                (10, np.nan),
+                (10, np.nan),
+            )
+        ),
+        framerate=20,
+    )
+
+    return xy1, xy2
+
+
+@pytest.fixture()
+def example_xy_objects_nan_horizontal() -> Tuple[XY, XY]:
+    xy1 = XY(
+        xy=np.array(
+            (
+                (0, 0),
+                (np.nan, np.nan),
+            )
+        ),
+        framerate=20,
+    )
+    xy2 = XY(
+        xy=np.array(
+            (
+                (10, 10),
+                (np.nan, np.nan),
+            )
+        ),
+        framerate=20,
+    )
+
+    return xy1, xy2

--- a/tests/test_models/conftest.py
+++ b/tests/test_models/conftest.py
@@ -213,30 +213,6 @@ def example_xy_objects_space_control_identical_positions() -> Tuple[XY, XY]:
 
 
 @pytest.fixture()
-def example_xy_objects_nan_vertical() -> Tuple[XY, XY]:
-    xy1 = XY(
-        xy=np.array(
-            (
-                (0, np.nan),
-                (0, np.nan),
-            )
-        ),
-        framerate=20,
-    )
-    xy2 = XY(
-        xy=np.array(
-            (
-                (10, np.nan),
-                (10, np.nan),
-            )
-        ),
-        framerate=20,
-    )
-
-    return xy1, xy2
-
-
-@pytest.fixture()
 def example_xy_objects_nan_horizontal() -> Tuple[XY, XY]:
     xy1 = XY(
         xy=np.array(
@@ -252,6 +228,30 @@ def example_xy_objects_nan_horizontal() -> Tuple[XY, XY]:
             (
                 (10, 10),
                 (np.nan, np.nan),
+            )
+        ),
+        framerate=20,
+    )
+
+    return xy1, xy2
+
+
+@pytest.fixture()
+def example_xy_objects_nan_vertical() -> Tuple[XY, XY]:
+    xy1 = XY(
+        xy=np.array(
+            (
+                (0, np.nan),
+                (0, np.nan),
+            )
+        ),
+        framerate=20,
+    )
+    xy2 = XY(
+        xy=np.array(
+            (
+                (10, np.nan),
+                (10, np.nan),
             )
         ),
         framerate=20,

--- a/tests/test_models/conftest.py
+++ b/tests/test_models/conftest.py
@@ -258,3 +258,76 @@ def example_xy_objects_nan_horizontal() -> Tuple[XY, XY]:
     )
 
     return xy1, xy2
+
+
+@pytest.fixture()
+def example_xy_objects_playercount_mismatch() -> Tuple[XY, XY]:
+    xy1 = XY(
+        xy=np.array(
+            (
+                (-25, 10, -25, -10),
+                (-25, 10, -25, -10),
+            )
+        ),
+        framerate=20,
+    )
+    xy2 = XY(
+        xy=np.array(
+            (
+                (25, 0),
+                (25, 0),
+            )
+        ),
+        framerate=20,
+    )
+
+    return xy1, xy2
+
+
+@pytest.fixture()
+def example_xy_objects_framecount_mismatch() -> Tuple[XY, XY]:
+    xy1 = XY(
+        xy=np.array(
+            (
+                (-25, 10, -25, -10),
+                (-25, 10, -25, -10),
+            )
+        ),
+        framerate=20,
+    )
+    xy2 = XY(
+        xy=np.array(
+            (
+                (25, 10, 25, -10),
+                (25, 10, 25, -10),
+                (25, 10, 25, -10),
+            )
+        ),
+        framerate=20,
+    )
+
+    return xy1, xy2
+
+
+@pytest.fixture()
+def example_xy_objects_out_of_pitch_bounds() -> Tuple[XY, XY]:
+    xy1 = XY(
+        xy=np.array(
+            (
+                (200, 0),
+                (200, 0),
+            )
+        ),
+        framerate=20,
+    )
+    xy2 = XY(
+        xy=np.array(
+            (
+                (10, 10),
+                (10, 10),
+            )
+        ),
+        framerate=20,
+    )
+
+    return xy1, xy2

--- a/tests/test_models/conftest.py
+++ b/tests/test_models/conftest.py
@@ -331,3 +331,19 @@ def example_xy_objects_out_of_pitch_bounds() -> Tuple[XY, XY]:
     )
 
     return xy1, xy2
+
+
+@pytest.fixture()
+def example_xy_objects_missing_second_team() -> Tuple[XY, None]:
+    xy1 = XY(
+        xy=np.array(
+            [
+                (0, 0),
+                (0, 0),
+            ]
+        ),
+        framerate=20,
+    )
+    xy2 = None
+
+    return xy1, xy2

--- a/tests/test_models/test_space.py
+++ b/tests/test_models/test_space.py
@@ -912,6 +912,18 @@ def test_out_of_pitch_bounds_taki_hasegawa(
         model.fit(xy1, xy2)
 
 
+@pytest.mark.unit
+def test_fit_with_missing_second_team(
+    example_xy_objects_missing_second_team, example_pitch_dfl
+) -> None:
+    xy1, xy2 = example_xy_objects_missing_second_team
+    pitch = example_pitch_dfl
+    model = SpaceControlModel(pitch, mesh="square", xpoints=10, model="taki_hasegawa")
+
+    with pytest.raises(TypeError, match="Both inputs must be valid XY objects."):
+        model.fit(xy1, xy2)
+
+
 # test calculation of player areas
 @pytest.mark.unit
 def test_player_controls_square(

--- a/tests/test_models/test_space.py
+++ b/tests/test_models/test_space.py
@@ -433,7 +433,9 @@ def test_calc_cell_controls_euclidean_square(
 ) -> None:
     xy1, xy2 = example_xy_objects_space_control
     pitch = example_pitch_dfl
-    model_square = SpaceControlModel(pitch, mesh="square", xpoints=10)
+    model_square = SpaceControlModel(
+        pitch, mesh="square", xpoints=10, model="euclidean"
+    )
     model_square.fit(xy1, xy2)
 
     assert np.array_equal(
@@ -468,7 +470,9 @@ def test_calc_cell_controls_euclidean_hex(
 ) -> None:
     xy1, xy2 = example_xy_objects_space_control
     pitch = example_pitch_dfl
-    model_hex = SpaceControlModel(pitch, mesh="hexagonal", xpoints=10)
+    model_hex = SpaceControlModel(
+        pitch, mesh="hexagonal", xpoints=10, model="euclidean"
+    )
     model_hex.fit(xy1, xy2)
 
     assert np.array_equal(
@@ -497,6 +501,355 @@ def test_calc_cell_controls_euclidean_hex(
         ),
         model_hex._cell_controls_[1],
     )
+
+
+# test calculation of controls with taki_hasegawa model
+@pytest.mark.unit
+def test_static_players_taki_hasegawa_square(
+    example_xy_objects_space_control_static_players, example_pitch_dfl
+) -> None:
+    xy1, xy2 = example_xy_objects_space_control_static_players
+    pitch = example_pitch_dfl
+    model_square = SpaceControlModel(
+        pitch, mesh="square", xpoints=10, model="taki_hasegawa"
+    )
+    model_square.fit(xy1, xy2)
+
+    assert np.array_equal(
+        np.array(
+            [
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            ]
+        ),
+        model_square._cell_controls_[0],
+    )
+    assert np.array_equal(
+        np.array(
+            [
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            ]
+        ),
+        model_square._cell_controls_[1],
+    )
+
+
+@pytest.mark.unit
+def test_p2_runs_at_p1_taki_hasegawa_square(
+    example_xy_objects_space_control_player2_runs_at_player1, example_pitch_dfl
+) -> None:
+    xy1, xy2 = example_xy_objects_space_control_player2_runs_at_player1
+    pitch = example_pitch_dfl
+    model_square = SpaceControlModel(
+        pitch, mesh="square", xpoints=10, model="taki_hasegawa"
+    )
+    model_square.fit(xy1, xy2)
+
+    assert np.array_equal(
+        np.array(
+            [
+                [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            ]
+        ),
+        model_square._cell_controls_[0],
+    )
+    assert np.array_equal(
+        np.array(
+            [
+                [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            ]
+        ),
+        model_square._cell_controls_[1],
+    )
+
+
+@pytest.mark.unit
+def test_players_towards_each_other_taki_hasegawa_square(
+    example_xy_objects_space_control_players_run_towards_each_other,
+    example_pitch_dfl,
+) -> None:
+    xy1, xy2 = example_xy_objects_space_control_players_run_towards_each_other
+    pitch = example_pitch_dfl
+    model_square = SpaceControlModel(
+        pitch, mesh="square", xpoints=10, model="taki_hasegawa"
+    )
+    model_square.fit(xy1, xy2)
+
+    assert np.array_equal(
+        np.array(
+            [
+                [1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+                [1.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0],
+                [1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+                [1.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0],
+                [1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+            ]
+        ),
+        model_square._cell_controls_[0],
+    )
+    assert np.array_equal(
+        np.array(
+            [
+                [1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+                [1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+                [1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+                [1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+                [1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+            ]
+        ),
+        model_square._cell_controls_[1],
+    )
+
+
+@pytest.mark.unit
+def test_players_same_direction_taki_hasegawa_square(
+    example_xy_objects_space_control_players_run_same_direction,
+    example_pitch_dfl,
+) -> None:
+    xy1, xy2 = example_xy_objects_space_control_players_run_same_direction
+    pitch = example_pitch_dfl
+    model_square = SpaceControlModel(
+        pitch, mesh="square", xpoints=10, model="taki_hasegawa"
+    )
+    model_square.fit(xy1, xy2)
+
+    assert np.array_equal(
+        np.array(
+            [
+                [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            ]
+        ),
+        model_square._cell_controls_[0],
+    )
+    assert np.array_equal(
+        np.array(
+            [
+                [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            ]
+        ),
+        model_square._cell_controls_[1],
+    )
+
+
+@pytest.mark.unit
+def test_static_players_taki_hasegawa_hex(
+    example_xy_objects_space_control_static_players, example_pitch_dfl
+) -> None:
+    xy1, xy2 = example_xy_objects_space_control_static_players
+    pitch = example_pitch_dfl
+    model_square = SpaceControlModel(
+        pitch, mesh="hexagonal", xpoints=10, model="taki_hasegawa"
+    )
+    model_square.fit(xy1, xy2)
+
+    assert np.array_equal(
+        np.array(
+            [
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            ]
+        ),
+        model_square._cell_controls_[0],
+    )
+    assert np.array_equal(
+        np.array(
+            [
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            ]
+        ),
+        model_square._cell_controls_[1],
+    )
+
+
+@pytest.mark.unit
+def test_p2_runs_at_p1_taki_hasegawa_hex(
+    example_xy_objects_space_control_player2_runs_at_player1, example_pitch_dfl
+) -> None:
+    xy1, xy2 = example_xy_objects_space_control_player2_runs_at_player1
+    pitch = example_pitch_dfl
+    model_square = SpaceControlModel(
+        pitch, mesh="hexagonal", xpoints=10, model="taki_hasegawa"
+    )
+    model_square.fit(xy1, xy2)
+
+    assert np.array_equal(
+        np.array(
+            [
+                [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            ]
+        ),
+        model_square._cell_controls_[0],
+    )
+    assert np.array_equal(
+        np.array(
+            [
+                [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            ]
+        ),
+        model_square._cell_controls_[1],
+    )
+
+
+@pytest.mark.unit
+def test_players_towards_each_other_taki_hasegawa_hex(
+    example_xy_objects_space_control_players_run_towards_each_other,
+    example_pitch_dfl,
+) -> None:
+    xy1, xy2 = example_xy_objects_space_control_players_run_towards_each_other
+    pitch = example_pitch_dfl
+    model_square = SpaceControlModel(
+        pitch, mesh="hexagonal", xpoints=10, model="taki_hasegawa"
+    )
+    model_square.fit(xy1, xy2)
+
+    assert np.array_equal(
+        np.array(
+            [
+                [1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+                [1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0],
+                [1.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+                [1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+                [1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            ]
+        ),
+        model_square._cell_controls_[0],
+    )
+    assert np.array_equal(
+        np.array(
+            [
+                [1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+                [1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0],
+                [1.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+                [1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+                [1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            ]
+        ),
+        model_square._cell_controls_[1],
+    )
+
+
+@pytest.mark.unit
+def test_players_same_direction_taki_hasegawa_hex(
+    example_xy_objects_space_control_players_run_same_direction,
+    example_pitch_dfl,
+) -> None:
+    xy1, xy2 = example_xy_objects_space_control_players_run_same_direction
+    pitch = example_pitch_dfl
+    model_square = SpaceControlModel(
+        pitch, mesh="hexagonal", xpoints=10, model="taki_hasegawa"
+    )
+    model_square.fit(xy1, xy2)
+
+    assert np.array_equal(
+        np.array(
+            [
+                [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            ]
+        ),
+        model_square._cell_controls_[0],
+    )
+    assert np.array_equal(
+        np.array(
+            [
+                [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            ]
+        ),
+        model_square._cell_controls_[1],
+    )
+
+
+# data quality test calculation of controls with identical positions
+@pytest.mark.unit
+def test_identical_positions_taki_hasegawa(
+    example_xy_objects_space_control_identical_positions, example_pitch_dfl
+) -> None:
+    xy1, xy2 = example_xy_objects_space_control_identical_positions
+    pitch = example_pitch_dfl
+    model = SpaceControlModel(pitch, mesh="square", xpoints=10, model="taki_hasegawa")
+    model.fit(xy1, xy2)
+
+    assert model._cell_controls_ is not None
+    assert not np.isnan(model._cell_controls_).all()
+
+
+@pytest.mark.unit
+def test_nan_horizontal_taki_hasegawa(
+    example_xy_objects_nan_horizontal, example_pitch_dfl
+) -> None:
+    xy1, xy2 = example_xy_objects_nan_horizontal
+    pitch = example_pitch_dfl
+    model = SpaceControlModel(pitch, mesh="square", xpoints=10, model="taki_hasegawa")
+    model.fit(xy1, xy2)
+
+    assert model._cell_controls_ is not None
+    assert not np.isnan(model._cell_controls_[0]).all()
+    assert np.isnan(model._cell_controls_[1]).all()
+
+
+@pytest.mark.unit
+def test_nan_vertical_taki_hasegawa(
+    example_xy_objects_nan_vertical, example_pitch_dfl
+) -> None:
+    xy1, xy2 = example_xy_objects_nan_vertical
+    pitch = example_pitch_dfl
+    model = SpaceControlModel(pitch, mesh="square", xpoints=10, model="taki_hasegawa")
+    model.fit(xy1, xy2)
+
+    assert np.isnan(model._cell_controls_).all()
 
 
 # test calculation of player areas

--- a/tests/test_models/test_space.py
+++ b/tests/test_models/test_space.py
@@ -813,6 +813,146 @@ def test_players_same_direction_taki_hasegawa_hex(
     )
 
 
+# data quality tests for euclidean model
+@pytest.mark.unit
+def test_identical_positions_euclidean(
+    example_xy_objects_space_control_identical_positions, example_pitch_dfl
+) -> None:
+    xy1, xy2 = example_xy_objects_space_control_identical_positions
+    pitch = example_pitch_dfl
+    model = SpaceControlModel(pitch, mesh="square", xpoints=10, model="euclidean")
+    model.fit(xy1, xy2)
+
+    assert np.array_equal(
+        np.zeros((5, 10)),
+        model._cell_controls_[0],
+    )
+    assert np.array_equal(
+        np.zeros((5, 10)),
+        model._cell_controls_[1],
+    )
+
+
+@pytest.mark.unit
+def test_nan_horizontal_euclidean(
+    example_xy_objects_nan_horizontal, example_pitch_dfl
+) -> None:
+    xy1, xy2 = example_xy_objects_nan_horizontal
+    pitch = example_pitch_dfl
+    model = SpaceControlModel(pitch, mesh="square", xpoints=10, model="euclidean")
+    model.fit(xy1, xy2)
+
+    assert np.array_equal(
+        np.array(
+            [
+                [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0],
+            ]
+        ),
+        model._cell_controls_[0],
+    )
+    assert np.allclose(
+        model._cell_controls_[1],
+        np.full((5, 10), np.nan),
+        equal_nan=True,
+    )
+
+
+@pytest.mark.unit
+def test_nan_vertical_euclidean(
+    example_xy_objects_nan_vertical, example_pitch_dfl
+) -> None:
+    xy1, xy2 = example_xy_objects_nan_vertical
+    pitch = example_pitch_dfl
+    model = SpaceControlModel(pitch, mesh="square", xpoints=10, model="euclidean")
+    model.fit(xy1, xy2)
+
+    assert np.allclose(
+        model._cell_controls_[0],
+        np.full((5, 10), np.nan),
+        equal_nan=True,
+    )
+    assert np.allclose(
+        model._cell_controls_[1],
+        np.full((5, 10), np.nan),
+        equal_nan=True,
+    )
+
+
+@pytest.mark.unit
+def test_playercount_mismatch_euclidean(
+    example_xy_objects_playercount_mismatch, example_pitch_dfl
+) -> None:
+    xy1, xy2 = example_xy_objects_playercount_mismatch
+    pitch = example_pitch_dfl
+    model = SpaceControlModel(pitch, mesh="square", xpoints=10, model="euclidean")
+    model.fit(xy1, xy2)
+
+    assert np.array_equal(
+        np.array(
+            [
+                [0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 2.0, 2.0, 2.0, 2.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 2.0, 2.0, 2.0, 2.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 2.0, 2.0, 2.0, 2.0],
+                [1.0, 1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.0],
+                [1.0, 1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.0],
+            ]
+        ),
+        model._cell_controls_[0],
+    )
+    assert np.array_equal(
+        np.array(
+            [
+                [0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 2.0, 2.0, 2.0, 2.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 2.0, 2.0, 2.0, 2.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 2.0, 2.0, 2.0, 2.0],
+                [1.0, 1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.0],
+                [1.0, 1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.0],
+            ]
+        ),
+        model._cell_controls_[1],
+    )
+
+
+@pytest.mark.unit
+def test_framecount_mismatch_euclidean(
+    example_xy_objects_framecount_mismatch, example_pitch_dfl
+) -> None:
+    xy1, xy2 = example_xy_objects_framecount_mismatch
+    pitch = example_pitch_dfl
+    model = SpaceControlModel(pitch, mesh="square", xpoints=10, model="euclidean")
+
+    with pytest.raises(ValueError, match="must have the same number of frames"):
+        model.fit(xy1, xy2)
+
+
+@pytest.mark.unit
+def test_out_of_pitch_bounds_euclidean(
+    example_xy_objects_out_of_pitch_bounds, example_pitch_dfl
+) -> None:
+    xy1, xy2 = example_xy_objects_out_of_pitch_bounds
+    pitch = example_pitch_dfl
+    model = SpaceControlModel(pitch, mesh="square", xpoints=10, model="euclidean")
+
+    with pytest.warns(UserWarning, match="outside the pitch boundaries"):
+        model.fit(xy1, xy2)
+
+
+@pytest.mark.unit
+def test_fit_with_missing_second_team_euclidean(
+    example_xy_objects_missing_second_team, example_pitch_dfl
+) -> None:
+    xy1, xy2 = example_xy_objects_missing_second_team
+    pitch = example_pitch_dfl
+    model = SpaceControlModel(pitch, mesh="square", xpoints=10, model="euclidean")
+
+    with pytest.raises(TypeError, match="Both inputs must be valid XY objects."):
+        model.fit(xy1, xy2)
+
+
 # data quality tests for taki_hasegawa model
 @pytest.mark.unit
 def test_identical_positions_taki_hasegawa(
@@ -823,8 +963,14 @@ def test_identical_positions_taki_hasegawa(
     model = SpaceControlModel(pitch, mesh="square", xpoints=10, model="taki_hasegawa")
     model.fit(xy1, xy2)
 
-    assert model._cell_controls_ is not None
-    assert not np.isnan(model._cell_controls_).all()
+    assert np.array_equal(
+        np.zeros((5, 10)),
+        model._cell_controls_[0],
+    )
+    assert np.array_equal(
+        np.zeros((5, 10)),
+        model._cell_controls_[1],
+    )
 
 
 @pytest.mark.unit
@@ -836,9 +982,23 @@ def test_nan_horizontal_taki_hasegawa(
     model = SpaceControlModel(pitch, mesh="square", xpoints=10, model="taki_hasegawa")
     model.fit(xy1, xy2)
 
-    assert model._cell_controls_ is not None
-    assert not np.isnan(model._cell_controls_[0]).all()
-    assert np.isnan(model._cell_controls_[1]).all()
+    assert np.array_equal(
+        np.array(
+            [
+                [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0],
+            ]
+        ),
+        model._cell_controls_[0],
+    )
+    assert np.allclose(
+        model._cell_controls_[1],
+        np.full((5, 10), np.nan),
+        equal_nan=True,
+    )
 
 
 @pytest.mark.unit
@@ -850,7 +1010,16 @@ def test_nan_vertical_taki_hasegawa(
     model = SpaceControlModel(pitch, mesh="square", xpoints=10, model="taki_hasegawa")
     model.fit(xy1, xy2)
 
-    assert np.isnan(model._cell_controls_).all()
+    assert np.allclose(
+        model._cell_controls_[0],
+        np.full((5, 10), np.nan),
+        equal_nan=True,
+    )
+    assert np.allclose(
+        model._cell_controls_[1],
+        np.full((5, 10), np.nan),
+        equal_nan=True,
+    )
 
 
 @pytest.mark.unit
@@ -908,7 +1077,7 @@ def test_out_of_pitch_bounds_taki_hasegawa(
     pitch = example_pitch_dfl
     model = SpaceControlModel(pitch, mesh="square", xpoints=10, model="taki_hasegawa")
 
-    with pytest.raises(ValueError, match="outside the pitch bounds"):
+    with pytest.warns(UserWarning, match="outside the pitch boundaries"):
         model.fit(xy1, xy2)
 
 

--- a/tests/test_models/test_space.py
+++ b/tests/test_models/test_space.py
@@ -503,7 +503,7 @@ def test_calc_cell_controls_euclidean_hex(
     )
 
 
-# test calculation of controls with taki_hasegawa model
+# test calculation of controls with taki_hasegawa model with square mesh
 @pytest.mark.unit
 def test_static_players_taki_hasegawa_square(
     example_xy_objects_space_control_static_players, example_pitch_dfl
@@ -654,16 +654,17 @@ def test_players_same_direction_taki_hasegawa_square(
     )
 
 
+# test calculation of controls with taki_hasegawa model with hexagonal mesh
 @pytest.mark.unit
 def test_static_players_taki_hasegawa_hex(
     example_xy_objects_space_control_static_players, example_pitch_dfl
 ) -> None:
     xy1, xy2 = example_xy_objects_space_control_static_players
     pitch = example_pitch_dfl
-    model_square = SpaceControlModel(
+    model_hex = SpaceControlModel(
         pitch, mesh="hexagonal", xpoints=10, model="taki_hasegawa"
     )
-    model_square.fit(xy1, xy2)
+    model_hex.fit(xy1, xy2)
 
     assert np.array_equal(
         np.array(
@@ -676,7 +677,7 @@ def test_static_players_taki_hasegawa_hex(
                 [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0],
             ]
         ),
-        model_square._cell_controls_[0],
+        model_hex._cell_controls_[0],
     )
     assert np.array_equal(
         np.array(
@@ -689,7 +690,7 @@ def test_static_players_taki_hasegawa_hex(
                 [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0],
             ]
         ),
-        model_square._cell_controls_[1],
+        model_hex._cell_controls_[1],
     )
 
 
@@ -699,10 +700,10 @@ def test_p2_runs_at_p1_taki_hasegawa_hex(
 ) -> None:
     xy1, xy2 = example_xy_objects_space_control_player2_runs_at_player1
     pitch = example_pitch_dfl
-    model_square = SpaceControlModel(
+    model_hex = SpaceControlModel(
         pitch, mesh="hexagonal", xpoints=10, model="taki_hasegawa"
     )
-    model_square.fit(xy1, xy2)
+    model_hex.fit(xy1, xy2)
 
     assert np.array_equal(
         np.array(
@@ -715,7 +716,7 @@ def test_p2_runs_at_p1_taki_hasegawa_hex(
                 [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
             ]
         ),
-        model_square._cell_controls_[0],
+        model_hex._cell_controls_[0],
     )
     assert np.array_equal(
         np.array(
@@ -728,7 +729,7 @@ def test_p2_runs_at_p1_taki_hasegawa_hex(
                 [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
             ]
         ),
-        model_square._cell_controls_[1],
+        model_hex._cell_controls_[1],
     )
 
 
@@ -739,10 +740,10 @@ def test_players_towards_each_other_taki_hasegawa_hex(
 ) -> None:
     xy1, xy2 = example_xy_objects_space_control_players_run_towards_each_other
     pitch = example_pitch_dfl
-    model_square = SpaceControlModel(
+    model_hex = SpaceControlModel(
         pitch, mesh="hexagonal", xpoints=10, model="taki_hasegawa"
     )
-    model_square.fit(xy1, xy2)
+    model_hex.fit(xy1, xy2)
 
     assert np.array_equal(
         np.array(
@@ -755,7 +756,7 @@ def test_players_towards_each_other_taki_hasegawa_hex(
                 [1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
             ]
         ),
-        model_square._cell_controls_[0],
+        model_hex._cell_controls_[0],
     )
     assert np.array_equal(
         np.array(
@@ -768,7 +769,7 @@ def test_players_towards_each_other_taki_hasegawa_hex(
                 [1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
             ]
         ),
-        model_square._cell_controls_[1],
+        model_hex._cell_controls_[1],
     )
 
 
@@ -779,10 +780,10 @@ def test_players_same_direction_taki_hasegawa_hex(
 ) -> None:
     xy1, xy2 = example_xy_objects_space_control_players_run_same_direction
     pitch = example_pitch_dfl
-    model_square = SpaceControlModel(
+    model_hex = SpaceControlModel(
         pitch, mesh="hexagonal", xpoints=10, model="taki_hasegawa"
     )
-    model_square.fit(xy1, xy2)
+    model_hex.fit(xy1, xy2)
 
     assert np.array_equal(
         np.array(
@@ -795,7 +796,7 @@ def test_players_same_direction_taki_hasegawa_hex(
                 [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
             ]
         ),
-        model_square._cell_controls_[0],
+        model_hex._cell_controls_[0],
     )
     assert np.array_equal(
         np.array(
@@ -808,11 +809,11 @@ def test_players_same_direction_taki_hasegawa_hex(
                 [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
             ]
         ),
-        model_square._cell_controls_[1],
+        model_hex._cell_controls_[1],
     )
 
 
-# data quality test calculation of controls with identical positions
+# data quality tests for taki_hasegawa model
 @pytest.mark.unit
 def test_identical_positions_taki_hasegawa(
     example_xy_objects_space_control_identical_positions, example_pitch_dfl
@@ -850,6 +851,65 @@ def test_nan_vertical_taki_hasegawa(
     model.fit(xy1, xy2)
 
     assert np.isnan(model._cell_controls_).all()
+
+
+@pytest.mark.unit
+def test_playercount_mismatch_taki_hasegawa(
+    example_xy_objects_playercount_mismatch, example_pitch_dfl
+) -> None:
+    xy1, xy2 = example_xy_objects_playercount_mismatch
+    pitch = example_pitch_dfl
+    model = SpaceControlModel(pitch, mesh="square", xpoints=10, model="taki_hasegawa")
+    model.fit(xy1, xy2)
+
+    assert np.array_equal(
+        np.array(
+            [
+                [0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 2.0, 2.0, 2.0, 2.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 2.0, 2.0, 2.0, 2.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 2.0, 2.0, 2.0, 2.0],
+                [1.0, 1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.0],
+                [1.0, 1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.0],
+            ]
+        ),
+        model._cell_controls_[0],
+    )
+    assert np.array_equal(
+        np.array(
+            [
+                [0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 2.0, 2.0, 2.0, 2.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 2.0, 2.0, 2.0, 2.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 2.0, 2.0, 2.0, 2.0],
+                [1.0, 1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.0],
+                [1.0, 1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.0],
+            ]
+        ),
+        model._cell_controls_[1],
+    )
+
+
+@pytest.mark.unit
+def test_framecount_mismatch_taki_hasegawa(
+    example_xy_objects_framecount_mismatch, example_pitch_dfl
+) -> None:
+    xy1, xy2 = example_xy_objects_framecount_mismatch
+    pitch = example_pitch_dfl
+    model = SpaceControlModel(pitch, mesh="square", xpoints=10, model="taki_hasegawa")
+
+    with pytest.raises(ValueError, match="must have the same number of frames"):
+        model.fit(xy1, xy2)
+
+
+@pytest.mark.unit
+def test_out_of_pitch_bounds_taki_hasegawa(
+    example_xy_objects_out_of_pitch_bounds, example_pitch_dfl
+) -> None:
+    xy1, xy2 = example_xy_objects_out_of_pitch_bounds
+    pitch = example_pitch_dfl
+    model = SpaceControlModel(pitch, mesh="square", xpoints=10, model="taki_hasegawa")
+
+    with pytest.raises(ValueError, match="outside the pitch bounds"):
+        model.fit(xy1, xy2)
 
 
 # test calculation of player areas

--- a/tests/test_models/test_space.py
+++ b/tests/test_models/test_space.py
@@ -4,10 +4,10 @@ import matplotlib
 import matplotlib.pyplot as plt
 
 from floodlight.core.pitch import Pitch
-from floodlight.models.space import DiscreteVoronoiModel
+from floodlight.models.space import SpaceControlModel
 
 
-# tests for DiscreteVoronoiModel (dvm)
+# tests for SpaceControlModel (dvm)
 @pytest.mark.unit
 def test_dvm_constructor(example_pitch_dfl) -> None:
     # create sample pitch
@@ -15,14 +15,14 @@ def test_dvm_constructor(example_pitch_dfl) -> None:
 
     # trigger constructor checks
     with pytest.raises(ValueError):
-        model = DiscreteVoronoiModel(pitch, mesh="foo")
+        model = SpaceControlModel(pitch, mesh="foo")
     with pytest.raises(ValueError):
-        model = DiscreteVoronoiModel(pitch, xpoints=9)
+        model = SpaceControlModel(pitch, xpoints=9)
     with pytest.raises(ValueError):
-        model = DiscreteVoronoiModel(pitch, xpoints=1001)
+        model = SpaceControlModel(pitch, xpoints=1001)
 
     # check correct executing of post_init
-    model = DiscreteVoronoiModel(pitch, xpoints=10)
+    model = SpaceControlModel(pitch, xpoints=10)
     assert not model.is_fitted
     assert model._meshx_ is not None
     assert model._meshy_ is not None
@@ -44,7 +44,7 @@ def test_generate_mesh_square() -> None:
     )
 
     # Opta
-    model = DiscreteVoronoiModel(pitch_opta, mesh="square", xpoints=xpoints)
+    model = SpaceControlModel(pitch_opta, mesh="square", xpoints=xpoints)
     assert np.allclose(
         np.array(
             [[5.0, 15.0, 25.0, 35.0, 45.0, 55.0, 65.0, 75.0, 85.0, 95.0]]
@@ -60,7 +60,7 @@ def test_generate_mesh_square() -> None:
         model._meshy_,
     )
     # StatsBomb
-    model = DiscreteVoronoiModel(pitch_statsbomb, mesh="square", xpoints=xpoints)
+    model = SpaceControlModel(pitch_statsbomb, mesh="square", xpoints=xpoints)
     assert np.allclose(
         np.array(
             [[6.0, 18.0, 30.0, 42.0, 54.0, 66.0, 78.0, 90.0, 102.0, 114.0]]
@@ -86,7 +86,7 @@ def test_generate_mesh_square() -> None:
         model._meshy_,
     )
     # DFL
-    model = DiscreteVoronoiModel(pitch_dfl, mesh="square", xpoints=xpoints)
+    model = SpaceControlModel(pitch_dfl, mesh="square", xpoints=xpoints)
     assert np.allclose(
         np.array(
             [[-49.05, -38.15, -27.25, -16.35, -5.45, 5.45, 16.35, 27.25, 38.15, 49.05]]
@@ -101,7 +101,7 @@ def test_generate_mesh_square() -> None:
         model._meshy_,
     )
     # Tracab
-    model = DiscreteVoronoiModel(pitch_tracab, mesh="square", xpoints=xpoints)
+    model = SpaceControlModel(pitch_tracab, mesh="square", xpoints=xpoints)
     assert np.allclose(
         np.array(
             [
@@ -129,7 +129,7 @@ def test_generate_mesh_square() -> None:
         model._meshy_,
     )
     # Statsperform
-    model = DiscreteVoronoiModel(pitch_statsperform, mesh="square", xpoints=xpoints)
+    model = SpaceControlModel(pitch_statsperform, mesh="square", xpoints=xpoints)
     assert np.allclose(
         np.array(
             [[5.45, 16.35, 27.25, 38.15, 49.05, 59.95, 70.85, 81.75, 92.65, 103.55]]
@@ -161,7 +161,7 @@ def test_generate_mesh_hex() -> None:
     )
 
     # Opta
-    model = DiscreteVoronoiModel(pitch_opta, mesh="hexagonal", xpoints=xpoints)
+    model = SpaceControlModel(pitch_opta, mesh="hexagonal", xpoints=xpoints)
     assert np.allclose(
         np.array(
             [
@@ -217,7 +217,7 @@ def test_generate_mesh_hex() -> None:
         model._meshy_,
     )
     # StatsBomb
-    model = DiscreteVoronoiModel(pitch_statsbomb, mesh="hexagonal", xpoints=xpoints)
+    model = SpaceControlModel(pitch_statsbomb, mesh="hexagonal", xpoints=xpoints)
     assert np.allclose(
         np.array(
             [
@@ -269,7 +269,7 @@ def test_generate_mesh_hex() -> None:
         model._meshy_,
     )
     # DFL
-    model = DiscreteVoronoiModel(pitch_dfl, mesh="hexagonal", xpoints=xpoints)
+    model = SpaceControlModel(pitch_dfl, mesh="hexagonal", xpoints=xpoints)
     assert np.allclose(
         np.array(
             [
@@ -321,7 +321,7 @@ def test_generate_mesh_hex() -> None:
         model._meshy_,
     )
     # Tracab
-    model = DiscreteVoronoiModel(pitch_tracab, mesh="hexagonal", xpoints=xpoints)
+    model = SpaceControlModel(pitch_tracab, mesh="hexagonal", xpoints=xpoints)
     assert np.allclose(
         np.array(
             [
@@ -373,7 +373,7 @@ def test_generate_mesh_hex() -> None:
         model._meshy_,
     )
     # Statsperform
-    model = DiscreteVoronoiModel(pitch_statsperform, mesh="hexagonal", xpoints=xpoints)
+    model = SpaceControlModel(pitch_statsperform, mesh="hexagonal", xpoints=xpoints)
     assert np.allclose(
         np.array(
             [
@@ -433,7 +433,7 @@ def test_calc_cell_controls_euclidean_square(
 ) -> None:
     xy1, xy2 = example_xy_objects_space_control
     pitch = example_pitch_dfl
-    model_square = DiscreteVoronoiModel(pitch, mesh="square", xpoints=10)
+    model_square = SpaceControlModel(pitch, mesh="square", xpoints=10)
     model_square.fit(xy1, xy2)
 
     assert np.array_equal(
@@ -468,7 +468,7 @@ def test_calc_cell_controls_euclidean_hex(
 ) -> None:
     xy1, xy2 = example_xy_objects_space_control
     pitch = example_pitch_dfl
-    model_hex = DiscreteVoronoiModel(pitch, mesh="hexagonal", xpoints=10)
+    model_hex = SpaceControlModel(pitch, mesh="hexagonal", xpoints=10)
     model_hex.fit(xy1, xy2)
 
     assert np.array_equal(
@@ -506,7 +506,7 @@ def test_player_controls_square(
 ) -> None:
     xy1, xy2 = example_xy_objects_space_control
     pitch = example_pitch_dfl
-    model_square = DiscreteVoronoiModel(pitch, mesh="square", xpoints=10)
+    model_square = SpaceControlModel(pitch, mesh="square", xpoints=10)
     model_square.fit(xy1, xy2)
 
     areas1, areas2 = model_square.player_controls()
@@ -530,7 +530,7 @@ def test_player_controls_hex(
 ) -> None:
     xy1, xy2 = example_xy_objects_space_control
     pitch = example_pitch_dfl
-    model_hex = DiscreteVoronoiModel(pitch, mesh="hexagonal", xpoints=10)
+    model_hex = SpaceControlModel(pitch, mesh="hexagonal", xpoints=10)
     model_hex.fit(xy1, xy2)
 
     areas1, areas2 = model_hex.player_controls()
@@ -555,7 +555,7 @@ def test_team_controls_square(
 ) -> None:
     xy1, xy2 = example_xy_objects_space_control
     pitch = example_pitch_dfl
-    model_square = DiscreteVoronoiModel(pitch, mesh="square", xpoints=10)
+    model_square = SpaceControlModel(pitch, mesh="square", xpoints=10)
     model_square.fit(xy1, xy2)
 
     areas1, areas2 = model_square.team_controls()
@@ -573,7 +573,7 @@ def test_team_controls_square(
 def test_team_controls_hex(example_xy_objects_space_control, example_pitch_dfl) -> None:
     xy1, xy2 = example_xy_objects_space_control
     pitch = example_pitch_dfl
-    model_hex = DiscreteVoronoiModel(pitch, mesh="hexagonal", xpoints=10)
+    model_hex = SpaceControlModel(pitch, mesh="hexagonal", xpoints=10)
     model_hex.fit(xy1, xy2)
 
     areas1, areas2 = model_hex.team_controls()
@@ -593,7 +593,7 @@ def test_plot_square(example_xy_objects_space_control, example_pitch_dfl) -> Non
     # get data
     xy1, xy2 = example_xy_objects_space_control
     pitch = example_pitch_dfl
-    model_square = DiscreteVoronoiModel(pitch, mesh="square", xpoints=10)
+    model_square = SpaceControlModel(pitch, mesh="square", xpoints=10)
     model_square.fit(xy1, xy2)
 
     # create plot
@@ -620,7 +620,7 @@ def test_plot_hex(example_xy_objects_space_control, example_pitch_dfl) -> None:
     # get data
     xy1, xy2 = example_xy_objects_space_control
     pitch = example_pitch_dfl
-    model_hex = DiscreteVoronoiModel(pitch, mesh="hexagonal", xpoints=10)
+    model_hex = SpaceControlModel(pitch, mesh="hexagonal", xpoints=10)
     model_hex.fit(xy1, xy2)
 
     # create plot
@@ -647,7 +647,7 @@ def test_plot_mesh(example_xy_objects_space_control, example_pitch_dfl) -> None:
     # get data
     xy1, xy2 = example_xy_objects_space_control
     pitch = example_pitch_dfl
-    model_hex = DiscreteVoronoiModel(pitch, mesh="hexagonal", xpoints=10)
+    model_hex = SpaceControlModel(pitch, mesh="hexagonal", xpoints=10)
     model_hex.fit(xy1, xy2)
 
     # create plot


### PR DESCRIPTION
This adds a motion-based model for space control following the formulation by Taki and Hasegawa (2000). The model assigns mesh cells to the player who can reach them fastest, considering initial velocity and maximum acceleration.

Includes:
- Arrival time calculation based on kinematic equations
- Support in SpaceControlModel via model="taki_hasegawa"
- Unit tests and data quality tests (NaN handling, mismatched inputs)
- Updated class and method docstrings for Sphinx HTML output

⚠️ This PR depends on #131 (`feat: VelocityVectorModel`) and uses functionality introduced there. Please merge that PR first, or review both together.