### PR TITLE
feat: add motion-based space control models (Taki-Hasegawa, Fujimura-Sugihara)

### DIFF
--- a/floodlight/models/space.py
+++ b/floodlight/models/space.py
@@ -8,19 +8,21 @@ from scipy.spatial.distance import cdist
 
 from floodlight import XY, Pitch, TeamProperty, PlayerProperty
 from floodlight.models.base import BaseModel, requires_fit
+from floodlight.models.kinematics import VelocityModel
 
 
 class DiscreteVoronoiModel(BaseModel):
-    """Calculates discretized versions of the Voronoi tessellation commonly used to
-    assess space control.
+    """Calculates discretized dominant regions commonly used to assess space control.
 
     Upon instantiation, this model creates a mesh grid that spans the entire pitch with
     a fixed number of mesh points. When calling the
-    :func:`~DiscreteVoronoiModel.fit`-method, closest players to the respective mesh
-    points are evaluated and their control assigned to players. Thus, cumulative
-    controls and controlled areas are calculated on a discretization of the pitch. The
-    following calculations can subsequently be queried by calling the corresponding
-    methods:
+    :func:`~DiscreteVoronoiModel.fit`-method, the controlling player for each mesh
+    point is determined according to the selected movement model. By default, the
+    Euclidean distance is used, which corresponds to a classical Voronoi tessellation.
+    Alternatively, motion-based models can be selected that account for player velocity
+    and acceleration. Cumulative controls and controlled areas are then calculated on a
+    discretization of the pitch. The following calculations can subsequently be queried
+    by calling the corresponding methods:
 
         - Player Space Control --> :func:`~DiscreteVoronoiModel.player_controls`
         - Team Space Control --> :func:`~DiscreteVoronoiModel.team_controls`
@@ -42,9 +44,25 @@ class DiscreteVoronoiModel(BaseModel):
         neighbours.
     xpoints: int, optional
         The number of mesh grid points used in x-direction. Must be in range [10, 1000]
-        and defaults to 100. The number of messh grid points in y-direction will be
+        and defaults to 100. The number of mesh grid points in y-direction will be
         inferred automatically to match the shape of the pitch and produce regular mesh
         cell shapes.
+    motion_model: {'euclidean', 'taki_hasegawa', 'fujimura_sugihara'}, optional
+        The motion model used to assign mesh points to players. 'euclidean'
+        (default) assigns each mesh point to the nearest player by Euclidean distance.
+        'taki_hasegawa' assigns each mesh point to the player who can reach it fastest,
+        considering initial velocity and maximum acceleration.
+        'fujimura_sugihara' uses an exponential velocity decay model where players
+        approach a terminal velocity with a drag coefficient.
+    max_acceleration: float, optional
+        Maximum player acceleration in m/s². Only used by 'taki_hasegawa'.
+        Defaults to 4.2 according to [5]_.
+    vmax: float, optional
+        Terminal velocity in m/s used by 'fujimura_sugihara'. Defaults to
+        7.8, according to [4]_ .
+    alpha: float, optional
+        Drag coefficient controlling how quickly players approach terminal
+        velocity used by 'fujimura_sugihara'. Defaults to 1.3 according to [4]_ .
 
     Notes
     -----
@@ -58,6 +76,43 @@ class DiscreteVoronoiModel(BaseModel):
     spatial inaccuracies of tracking data as well as variations in moving players'
     centers of masses.
 
+    In addition to the Euclidean model, this class supports the motion-based model by
+    Taki and Hasegawa [1]_. This approach assigns each mesh point to the player who can
+    reach it fastest, considering both current velocity and maximum acceleration. For
+    each player at position :math:`\\mathbf{p}` with velocity :math:`\\mathbf{v}`, the
+    minimum arrival time :math:`t^*` to a target point :math:`\\mathbf{x}` under the
+    isotropic acceleration constraint :math:`\\|\\mathbf{a}\\| \\leq a_{max}` is the
+    smallest :math:`t \\ge 0` satisfying:
+
+    .. math::
+
+        \\|\\mathbf{x} - \\mathbf{p} - \\mathbf{v} t\\| \\leq \\frac{1}{2} a_{max} t^2
+
+    This is solved numerically via bisection on the feasibility function
+    :math:`g(t) = \\|\\mathbf{x} - \\mathbf{p} - \\mathbf{v} t\\|
+    - \\frac{1}{2} a_{max} t^2`, using a velocity-projection quadratic as lower bound
+    and a stop-then-go strategy as upper bound for initial bracketing.
+
+    The model by Fujimura and Sugihara [4]_ extends this by modeling player motion with
+    an exponential decay of acceleration instead of constant acceleration. A player's
+    velocity approaches a terminal speed :math:`v_{max}` with drag coefficient
+    :math:`\\alpha`. The center of the reachable region by time :math:`t` is displaced
+    by :math:`\\varphi(t) = (1 - e^{-\\alpha t}) / \\alpha` along the initial velocity
+    direction, while the reachable radius grows as
+    :math:`v_{max} (t - \\varphi(t))`. The arrival time is the smallest :math:`t \\ge 0`
+    satisfying:
+
+    .. math::
+
+        \\|\\mathbf{x} - \\mathbf{p} - \\varphi(t) \\mathbf{v}\\|
+        \\leq v_{max} (t - \\varphi(t))
+
+    .. note::
+        Computation time scales with the number of mesh points, players, and frames.
+        Motion-based models (``'taki_hasegawa'``, ``'fujimura_sugihara'``) are
+        significantly more expensive than the Euclidean model. For high-resolution
+        meshes and long sequences, fitting may take several minutes.
+
     References
     ----------
         .. [1] `Taki, T., & Hasegawa, J. (2000). Visualization of dominant region in
@@ -67,10 +122,16 @@ class DiscreteVoronoiModel(BaseModel):
         .. [2] `Fonseca, S., Milho, J., Travassos, B., & Araújo, D. (2012). Spatial
             dynamics of team sports exposed by Voronoi diagrams. Human Movement
             Science, 31(6), 1652–1659. <https://doi.org/10.1016/j.humov.2012.04.006>`_
-        .. [3] `Rein, R., Raabe, D., & Memmert, D. (2017). “Which pass is better?”
+        .. [3] `Rein, R., Raabe, D., & Memmert, D. (2017). "Which pass is better?"
             Novel approaches to assess passing effectiveness in elite soccer. Human
             Movement Science, 55, 172–181.
             <https://doi.org/10.1016/j.humov.2017.07.010>`_
+        .. [4] `Fujimura, A., & Sugihara, K. (2005). Geometric analysis and
+            quantitative evaluation of sport teamwork. Systems and Computers in
+            Japan, 36(6), 49–58. <https://doi.org/10.1002/scj.20254>`_
+        .. [5] `Brefeld, U., Lasek, J., & Mair, S. (2019). Probabilistic movement
+            models and zones of control. Machine Learning, 108(1), 127–147.
+            <https://doi.org/10.1007/s10994-018-5725-1>`_
 
     Examples
     --------
@@ -98,12 +159,25 @@ class DiscreteVoronoiModel(BaseModel):
      [46.91]]
     """
 
-    def __init__(self, pitch: Pitch, mesh: str = "square", xpoints: int = 100):
+    def __init__(
+        self,
+        pitch: Pitch,
+        mesh: str = "square",
+        xpoints: int = 100,
+        motion_model: str = "euclidean",
+        max_acceleration: float = 4.2,
+        vmax: float = 7.8,
+        alpha: float = 1.3,
+    ):
         super().__init__(pitch)
 
         # input parameter
         self._mesh_type = mesh
         self._xpoints = xpoints
+        self._motion_model = motion_model
+        self._max_acceleration = max_acceleration
+        self._vmax = vmax
+        self._alpha = alpha
 
         # model parameter
         self._meshx_ = None
@@ -116,6 +190,11 @@ class DiscreteVoronoiModel(BaseModel):
         self._framerate = None
         self._cell_controls_ = None
 
+        # velocity and speed for motion-based models, not checked by is_fitted
+        self._vel1 = None
+        self._vel2 = None
+        self._speed1 = None
+        self._speed2 = None
         # checks
         valid_mesh_types = ["square", "hexagonal"]
         if mesh not in valid_mesh_types:
@@ -125,6 +204,12 @@ class DiscreteVoronoiModel(BaseModel):
         if xpoints < 10 or xpoints > 1000:
             raise ValueError(
                 f"Expected xpoints to be in range [10, 1000], got {xpoints}"
+            )
+        valid_motion_models = ["euclidean", "taki_hasegawa", "fujimura_sugihara"]
+        if motion_model not in valid_motion_models:
+            raise ValueError(
+                f"Invalid motion_model. Expected one of "
+                f"{valid_motion_models}, got '{motion_model}'"
             )
 
         # generate mesh
@@ -181,27 +266,314 @@ class DiscreteVoronoiModel(BaseModel):
             # add offset for odd rows
             self._meshx_[1::2, :] += xpad
 
+    def _compute_velocities(self, xy1: XY, xy2: XY):
+        """Compute velocity vectors and speeds for both teams using VelocityModel."""
+        vm = VelocityModel()
+
+        vm.fit(xy1, axis="x")
+        vx1 = vm.velocity().property
+        vm.fit(xy1, axis="y")
+        vy1 = vm.velocity().property
+        vm.fit(xy1)
+        self._vel1 = np.stack((vx1, vy1), axis=2)
+        self._speed1 = vm.velocity().property
+
+        vm.fit(xy2, axis="x")
+        vx2 = vm.velocity().property
+        vm.fit(xy2, axis="y")
+        vy2 = vm.velocity().property
+        vm.fit(xy2)
+        self._vel2 = np.stack((vx2, vy2), axis=2)
+        self._speed2 = vm.velocity().property
+
+    @staticmethod
+    def _bisect_roots(
+        g_func,
+        t_lo: np.ndarray,
+        t_hi: np.ndarray,
+        tol: float = 1e-2,
+        max_iter: int = 10,
+    ) -> np.ndarray:
+        """Find roots of a feasibility function via bracketed bisection.
+
+        Solves for the smallest ``t`` such that ``g_func(t) <= 0`` using
+        bisection on the bracket ``[t_lo, t_hi]``. Resets ``t_lo`` to 0 where
+        numerically already feasible. Callers must provide proven analytical
+        bounds that guarantee ``t_lo`` is infeasible and ``t_hi`` is feasible.
+
+        Parameters
+        ----------
+        g_func: callable
+            Feasibility function mapping ``np.ndarray`` of shape (K,) to
+            ``np.ndarray`` of shape (K,). Negative values indicate feasibility.
+        t_lo: np.ndarray
+            Array of shape (K,) with analytical lower bounds (infeasible).
+        t_hi: np.ndarray
+            Array of shape (K,) with analytical upper bounds (feasible).
+        tol: float, optional
+            Convergence tolerance in seconds. Defaults to 1e-2.
+        max_iter: int, optional
+            Maximum number of bisection iterations. Each iteration halves the
+            bracket, so 10 iterations reduce it by a factor of 2^10 = 1024.
+            Iteration stops early if all brackets are below ``tol``.
+            Defaults to 10.
+
+        Returns
+        -------
+        roots: np.ndarray
+            Array of shape (K,) with the root estimates (upper bound of final
+            bracket).
+        """
+        # reset lower bound to 0 where numerically already feasible
+        g_lo = g_func(t_lo)
+        t_lo[g_lo <= 0.0] = 0.0
+
+        # fixed-iteration bisection with global early stop
+        for _ in range(max_iter):
+            t_mid = 0.5 * (t_lo + t_hi)
+            g_mid = g_func(t_mid)
+            feasible = g_mid <= 0.0
+            t_hi[feasible] = t_mid[feasible]
+            t_lo[~feasible] = t_mid[~feasible]
+            if np.max(t_hi - t_lo) < tol:
+                break
+
+        return t_hi
+
+    def _taki_hasegawa_arrival_time(
+        self,
+        mesh_points: np.ndarray,
+        player_positions: np.ndarray,
+        player_velocities: np.ndarray,
+        player_speeds: np.ndarray,
+    ) -> np.ndarray:
+        """Compute arrival times using the Taki & Hasegawa (2000) kinematic model.
+
+        Finds the minimum time for each player to reach each mesh point under the
+        isotropic acceleration constraint ``||a|| <= max_acceleration``. Uses
+        bisection root-finding on the feasibility function with analytical lower
+        and upper bounds for tight initial bracketing. See class-level Notes for
+        the mathematical formulation.
+
+        Parameters
+        ----------
+        mesh_points: np.ndarray
+            Array of shape (M, 2) with mesh point coordinates.
+        player_positions: np.ndarray
+            Array of shape (P, 2) with player coordinates (may contain NaN).
+        player_velocities: np.ndarray
+            Array of shape (P, 2) with player velocity vectors.
+        player_speeds: np.ndarray
+            Array of shape (P,) with player scalar speeds.
+
+        Returns
+        -------
+        arrival_times: np.ndarray
+            Array of shape (M, P) with arrival times. NaN where player position
+            data is invalid.
+        """
+        M = mesh_points.shape[0]
+        P = player_positions.shape[0]
+        amax = self._max_acceleration
+        arrival_times = np.full((P, M), np.nan, dtype=float)
+
+        for p in range(P):
+            pos = player_positions[p]
+            vel = player_velocities[p]
+            speed = float(player_speeds[p])
+
+            # skip NaN players
+            if np.any(np.isnan(pos)):
+                continue
+
+            # NaN velocity at valid position (gradient edge effect)
+            if np.any(np.isnan(vel)):
+                vel = np.zeros(2, dtype=float)
+                speed = 0.0
+
+            # displacement and distance from player to each mesh point
+            disp = mesh_points - pos  # (M, 2)
+            dist = np.linalg.norm(disp, axis=1)  # (M,)
+
+            # filter out zero-distance points to avoid division by zero
+            # in direction computation; assign them t=0
+            solve = dist > 0.0
+            arrival_times[p, ~solve] = 0.0
+
+            r = disp[solve]  # (K, 2)
+            d = dist[solve]  # (K,)
+
+            # lower bound: velocity projection quadratic
+            direction = r / d[:, np.newaxis]
+            v_proj = np.sum(vel * direction, axis=1)
+            t_lo = (-v_proj + np.sqrt(v_proj**2 + 2.0 * amax * d)) / amax
+
+            # stationary player: both bounds are exact, skip bisection
+            if speed == 0.0:
+                arrival_times[p, solve] = t_lo
+                continue
+
+            # upper bound: stop-then-go strategy
+            t_stop = speed / amax
+            stop_pos = pos + vel * t_stop - 0.5 * (vel / speed) * amax * t_stop**2
+            d_go = np.linalg.norm(mesh_points[solve] - stop_pos, axis=1)
+            t_hi = t_stop + np.sqrt(2.0 * d_go / amax)
+
+            # feasibility function: g(t) <= 0 means reachable by time t
+            def _g(t_vec):
+                rt = r - vel[np.newaxis, :] * t_vec[:, np.newaxis]
+                return np.linalg.norm(rt, axis=1) - 0.5 * amax * t_vec**2
+
+            arrival_times[p, solve] = DiscreteVoronoiModel._bisect_roots(
+                _g,
+                t_lo,
+                t_hi,
+            )
+
+        return np.transpose(arrival_times)
+
+    def _fujimura_sugihara_arrival_time(
+        self,
+        mesh_points: np.ndarray,
+        player_positions: np.ndarray,
+        player_velocities: np.ndarray,
+        player_speeds: np.ndarray,
+    ) -> np.ndarray:
+        """Compute arrival times using the Fujimura & Sugihara (2005) model.
+
+        Models player motion with an exponential velocity decay toward a terminal
+        speed ``vmax`` with drag coefficient ``alpha``. Uses bisection
+        root-finding on the feasibility function with analytical bounds. See
+        class-level Notes for the mathematical formulation.
+
+        Parameters
+        ----------
+        mesh_points: np.ndarray
+            Array of shape (M, 2) with mesh point coordinates.
+        player_positions: np.ndarray
+            Array of shape (P, 2) with player coordinates (may contain NaN).
+        player_velocities: np.ndarray
+            Array of shape (P, 2) with player velocity vectors.
+        player_speeds: np.ndarray
+            Array of shape (P,) with player scalar speeds.
+
+        Returns
+        -------
+        arrival_times: np.ndarray
+            Array of shape (M, P) with arrival times. NaN where player position
+            data is invalid.
+        """
+        M = mesh_points.shape[0]
+        P = player_positions.shape[0]
+        vmax = self._vmax
+        alpha = self._alpha
+        arrival_times = np.full((P, M), np.nan, dtype=float)
+
+        for p in range(P):
+            pos = player_positions[p]
+            vel = player_velocities[p]
+            speed = float(player_speeds[p])
+
+            # skip NaN players
+            if np.any(np.isnan(pos)):
+                continue
+
+            # NaN velocity at valid position (gradient edge effect)
+            if np.any(np.isnan(vel)):
+                vel = np.zeros(2, dtype=float)
+                speed = 0.0
+
+            # displacement and distance from player to each mesh point
+            disp = mesh_points - pos  # (M, 2)
+            dist = np.linalg.norm(disp, axis=1)  # (M,)
+
+            # filter out zero-distance points; assign them t=0
+            solve = dist > 0.0
+            arrival_times[p, ~solve] = 0.0
+
+            r = disp[solve]  # (K, 2)
+            d = dist[solve]  # (K,)
+
+            # lower bound: best case distance reduction
+            t_lo = np.maximum(0.0, d - speed / alpha) / vmax
+
+            # upper bound: conservative estimate
+            t_hi = 1.0 / alpha + d / vmax + speed / (alpha * vmax)
+
+            # phi(t) = (1 - exp(-alpha * t)) / alpha
+            def _phi(t_vec):
+                return (1.0 - np.exp(-alpha * t_vec)) / alpha
+
+            # feasibility function: g(t) <= 0 means reachable by time t
+            def _g(t_vec):
+                ph = _phi(t_vec)
+                rt = r - vel[np.newaxis, :] * ph[:, np.newaxis]
+                return np.linalg.norm(rt, axis=1) - vmax * (t_vec - ph)
+
+            arrival_times[p, solve] = DiscreteVoronoiModel._bisect_roots(
+                _g,
+                t_lo,
+                t_hi,
+            )
+
+        return np.transpose(arrival_times)
+
     def _calc_cell_controls(self, xy1: XY, xy2: XY):
-        """Calculates xID of closest player to each mesh point at each time point and
-        stores results in self._cell_controls"""
-        # bin
+        """Calculate the xID of the controlling player for each mesh point at each
+        frame.
+
+        Dispatches to the appropriate arrival-time method based on
+        ``self._motion_model`` and assigns each cell to the player with
+        the lowest cost. All-NaN frames are skipped.
+        """
         T = len(xy1)
         self._cell_controls_ = np.full(
-            # shape is: time x (mesh shape)
             (T, self._meshx_.shape[0], self._meshx_.shape[1]),
             np.nan,
         )
 
-        # loop
-        for t in range(T):
-            # stack and reshape player and mesh coordinates to (M x 2) arrays
-            player_points = np.hstack((xy1.frame(t), xy2.frame(t))).reshape(-1, 2)
-            mesh_points = np.stack((self._meshx_, self._meshy_), axis=2).reshape(-1, 2)
+        # flatten mesh to (M, 2) — computed once outside the loop
+        mesh_points = np.stack((self._meshx_, self._meshy_), axis=2).reshape(-1, 2)
 
-            # calculate pairwise distances and determine closest player
-            pairwise_distances = cdist(mesh_points, player_points)
-            closest_player_index = np.nanargmin(pairwise_distances, axis=1)
-            self._cell_controls_[t] = closest_player_index.reshape(self._meshx_.shape)
+        # pre-stack player positions from both teams: (T, P, 2)
+        all_positions = np.hstack((xy1.xy, xy2.xy)).reshape(T, -1, 2)
+
+        # pre-stack velocities and speeds for motion-based models
+        if self._motion_model in ["taki_hasegawa", "fujimura_sugihara"]:
+            all_velocities = np.concatenate(
+                (self._vel1, self._vel2), axis=1
+            )  # (T, P, 2)
+            all_speeds = np.concatenate((self._speed1, self._speed2), axis=1)  # (T, P)
+
+        for t in range(T):
+            player_positions = all_positions[t]
+
+            # skip all-NaN frames (e.g., halftime, breaks)
+            if np.all(np.isnan(player_positions)):
+                continue
+
+            # compute cost matrix based on motion model type
+            if self._motion_model == "euclidean":
+                costs = cdist(mesh_points, player_positions)
+            elif self._motion_model == "taki_hasegawa":
+                costs = self._taki_hasegawa_arrival_time(
+                    mesh_points,
+                    player_positions,
+                    all_velocities[t],
+                    all_speeds[t],
+                )
+            elif self._motion_model == "fujimura_sugihara":
+                costs = self._fujimura_sugihara_arrival_time(
+                    mesh_points,
+                    player_positions,
+                    all_velocities[t],
+                    all_speeds[t],
+                )
+
+            # assign each mesh cell to the player with lowest cost
+            self._cell_controls_[t] = np.nanargmin(costs, axis=1).reshape(
+                self._meshx_.shape
+            )
 
     def fit(self, xy1: XY, xy2: XY):
         """Fit the model to the given data and calculate control values for mesh points.
@@ -218,6 +590,11 @@ class DiscreteVoronoiModel(BaseModel):
         self._N2_ = xy2.N
         self._T_ = len(xy1)
         self._framerate = xy1.framerate
+
+        # compute velocities for motion-based models
+        if self._motion_model in ["taki_hasegawa", "fujimura_sugihara"]:
+            self._compute_velocities(xy1, xy2)
+
         # invoke control calculation
         self._calc_cell_controls(xy1, xy2)
 
@@ -384,11 +761,14 @@ class DiscreteVoronoiModel(BaseModel):
         yoffset = -(self._ypolysize_ * 0.5)
         # loop through mesh points and plot Rectangle patch
         for i, j in np.ndindex(self._meshx_.shape):
+            control_value = self._cell_controls_[t, i, j]
+            if np.isnan(control_value):
+                continue
             poly = plt.Rectangle(
                 (self._meshx_[i, j] + xoffset, self._meshy_[i, j] + yoffset),
                 width=self._xpolysize_,
                 height=self._ypolysize_,
-                fc=team_colors[int(self._cell_controls_[t, i, j])],
+                fc=team_colors[int(control_value)],
                 ec=ec,
                 alpha=alpha,
                 **kwargs,
@@ -413,11 +793,14 @@ class DiscreteVoronoiModel(BaseModel):
         n_vertices = 6
         # loop through mesh points and plot RegularPolygon patch
         for (i, j), x in np.ndenumerate(self._meshx_):
+            control_value = self._cell_controls_[t, i, j]
+            if np.isnan(control_value):
+                continue
             poly = RegularPolygon(
                 (x, self._meshy_[i, j]),
                 numVertices=n_vertices,
                 radius=self._xpolysize_,
-                fc=team_colors[int(self._cell_controls_[t, i, j])],
+                fc=team_colors[int(control_value)],
                 ec=ec,
                 alpha=alpha,
                 **kwargs,

--- a/tests/test_models/conftest.py
+++ b/tests/test_models/conftest.py
@@ -107,6 +107,32 @@ def example_xy_objects_space_control() -> Tuple[XY, XY]:
     return xy1, xy2
 
 
+# sample data for testing motion-based space control models (lower framerate for
+# realistic velocities: 1m displacement at 5fps = 5 m/s)
+@pytest.fixture()
+def example_xy_objects_motion_space_control() -> Tuple[XY, XY]:
+    xy1 = XY(
+        xy=np.array(
+            (
+                (-30, 0, 0, 0, 0, 10),
+                (-31, 0, 0, 0, 1, 11),
+            )
+        ),
+        framerate=5,
+    )
+    xy2 = XY(
+        xy=np.array(
+            (
+                (30, 0, 0, 0, 4, -10),
+                (31, 0, np.nan, np.nan, 5, -11),
+            )
+        ),
+        framerate=5,
+    )
+
+    return xy1, xy2
+
+
 # sample data with one frame having all nan (horizontal nan slice) for two teams
 @pytest.fixture()
 def example_xy_objects_horizontal_nan() -> Tuple[XY, XY]:

--- a/tests/test_models/test_space.py
+++ b/tests/test_models/test_space.py
@@ -20,6 +20,8 @@ def test_dvm_constructor(example_pitch_dfl) -> None:
         model = DiscreteVoronoiModel(pitch, xpoints=9)
     with pytest.raises(ValueError):
         model = DiscreteVoronoiModel(pitch, xpoints=1001)
+    with pytest.raises(ValueError):
+        model = DiscreteVoronoiModel(pitch, motion_model="foo")
 
     # check correct executing of post_init
     model = DiscreteVoronoiModel(pitch, xpoints=10)
@@ -659,3 +661,163 @@ def test_plot_mesh(example_xy_objects_space_control, example_pitch_dfl) -> None:
     assert isinstance(ax, matplotlib.axes.Axes)
 
     plt.close()
+
+
+# tests for motion-based models
+@pytest.mark.unit
+def test_bisect_roots() -> None:
+    # g(t) = 5 - t has root at t = 5 (positive = infeasible, negative = feasible)
+    def g(t):
+        return 5.0 - t
+
+    t_lo = np.array([0.0, 1.0, 3.0])
+    t_hi = np.array([10.0, 8.0, 6.0])
+
+    roots = DiscreteVoronoiModel._bisect_roots(g, t_lo, t_hi)
+
+    assert np.allclose(roots, 5.0, atol=1e-2)
+
+
+@pytest.mark.unit
+def test_calc_cell_controls_taki_hasegawa(
+    example_xy_objects_motion_space_control, example_pitch_dfl
+) -> None:
+    xy1, xy2 = example_xy_objects_motion_space_control
+    pitch = example_pitch_dfl
+    model = DiscreteVoronoiModel(
+        pitch, mesh="square", xpoints=10, motion_model="taki_hasegawa"
+    )
+    model.fit(xy1, xy2)
+
+    assert np.array_equal(
+        np.array(
+            [
+                [0.0, 0.0, 0.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 3.0],
+                [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0],
+                [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 3.0, 3.0, 3.0],
+                [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 5.0, 5.0, 3.0, 3.0],
+                [0.0, 0.0, 0.0, 1.0, 1.0, 5.0, 5.0, 5.0, 5.0, 3.0],
+            ]
+        ),
+        model._cell_controls_[0],
+    )
+    assert np.array_equal(
+        np.array(
+            [
+                [0.0, 0.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 3.0],
+                [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0],
+                [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 3.0, 3.0, 3.0],
+                [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 5.0, 5.0, 3.0, 3.0],
+                [0.0, 0.0, 1.0, 1.0, 1.0, 5.0, 5.0, 5.0, 5.0, 3.0],
+            ]
+        ),
+        model._cell_controls_[1],
+    )
+
+
+@pytest.mark.unit
+def test_calc_cell_controls_fujimura_sugihara(
+    example_xy_objects_motion_space_control, example_pitch_dfl
+) -> None:
+    xy1, xy2 = example_xy_objects_motion_space_control
+    pitch = example_pitch_dfl
+    model = DiscreteVoronoiModel(
+        pitch, mesh="square", xpoints=10, motion_model="fujimura_sugihara"
+    )
+    model.fit(xy1, xy2)
+
+    assert np.array_equal(
+        np.array(
+            [
+                [0.0, 0.0, 0.0, 2.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0],
+                [0.0, 0.0, 0.0, 1.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0],
+                [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 3.0, 3.0, 3.0],
+                [0.0, 0.0, 0.0, 1.0, 1.0, 5.0, 5.0, 3.0, 3.0, 3.0],
+                [0.0, 0.0, 0.0, 5.0, 5.0, 5.0, 5.0, 5.0, 3.0, 3.0],
+            ]
+        ),
+        model._cell_controls_[0],
+    )
+    assert np.array_equal(
+        np.array(
+            [
+                [0.0, 0.0, 0.0, 2.0, 2.0, 2.0, 2.0, 2.0, 3.0, 3.0],
+                [0.0, 0.0, 0.0, 1.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0],
+                [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 3.0, 3.0, 3.0],
+                [0.0, 0.0, 0.0, 1.0, 1.0, 5.0, 5.0, 3.0, 3.0, 3.0],
+                [0.0, 0.0, 0.0, 5.0, 5.0, 5.0, 5.0, 5.0, 3.0, 3.0],
+            ]
+        ),
+        model._cell_controls_[1],
+    )
+
+
+@pytest.mark.unit
+def test_motion_model_differs_from_euclidean(
+    example_xy_objects_motion_space_control, example_pitch_dfl
+) -> None:
+    xy1, xy2 = example_xy_objects_motion_space_control
+    pitch = example_pitch_dfl
+
+    dvm_eucl = DiscreteVoronoiModel(
+        pitch, mesh="square", xpoints=10, motion_model="euclidean"
+    )
+    dvm_taki = DiscreteVoronoiModel(
+        pitch, mesh="square", xpoints=10, motion_model="taki_hasegawa"
+    )
+    dvm_fuji = DiscreteVoronoiModel(
+        pitch, mesh="square", xpoints=10, motion_model="fujimura_sugihara"
+    )
+    dvm_eucl.fit(xy1, xy2)
+    dvm_taki.fit(xy1, xy2)
+    dvm_fuji.fit(xy1, xy2)
+
+    # all three models should produce different cell controls
+    assert not np.array_equal(dvm_eucl._cell_controls_, dvm_taki._cell_controls_)
+    assert not np.array_equal(dvm_eucl._cell_controls_, dvm_fuji._cell_controls_)
+    assert not np.array_equal(dvm_taki._cell_controls_, dvm_fuji._cell_controls_)
+
+
+@pytest.mark.unit
+def test_motion_model_nan_handling(
+    example_xy_objects_horizontal_nan, example_pitch_dfl
+) -> None:
+    xy1, xy2 = example_xy_objects_horizontal_nan
+    pitch = example_pitch_dfl
+
+    model = DiscreteVoronoiModel(
+        pitch, mesh="square", xpoints=10, motion_model="taki_hasegawa"
+    )
+    model.fit(xy1, xy2)
+
+    # all-NaN frame should remain NaN in cell controls
+    assert np.all(np.isnan(model._cell_controls_[1]))
+    # valid frames should have no NaN
+    assert not np.any(np.isnan(model._cell_controls_[0]))
+    assert not np.any(np.isnan(model._cell_controls_[2]))
+
+
+@pytest.mark.unit
+def test_compute_velocities(
+    example_xy_objects_motion_space_control, example_pitch_dfl
+) -> None:
+    xy1, xy2 = example_xy_objects_motion_space_control
+    pitch = example_pitch_dfl
+    model = DiscreteVoronoiModel(
+        pitch, mesh="square", xpoints=10, motion_model="taki_hasegawa"
+    )
+    model.fit(xy1, xy2)
+
+    # check velocity vector shapes: (T, N, 2)
+    assert model._vel1.shape == (2, 3, 2)
+    assert model._vel2.shape == (2, 3, 2)
+    # check speed shapes: (T, N)
+    assert model._speed1.shape == (2, 3)
+    assert model._speed2.shape == (2, 3)
+    # velocities should not be set for euclidean model
+    model_eucl = DiscreteVoronoiModel(
+        pitch, mesh="square", xpoints=10, motion_model="euclidean"
+    )
+    model_eucl.fit(xy1, xy2)
+    assert model_eucl._vel1 is None
+    assert model_eucl._speed1 is None


### PR DESCRIPTION
This adds a motion-based space control model following Fujimura and Sugihara (2005), which introduces a velocity-dependent resistive force that limits acceleration and produces asymptotic speed behavior—yielding more realistic estimates of how quickly players can reach each point on the pitch.

Includes:

- Support in SpaceControlModel via model="fujimura_sugihara"
- Arrival time calculation based on kinematic equations
- Unit tests and data quality checks for player count, frame count, pitch bounds, NaN handling, and square/hex meshes

⚠️ This PR depends on https://github.com/floodlight-sports/floodlight/pull/159 (feat: add Taki-Hasegawa model to SpaceControlModel). Please merge that PR first, or review both together.
