### PR TITLE
feat: zone aggregation metric

### DIFF
--- a/docs/source/modules/metrics/metrics.rst
+++ b/docs/source/modules/metrics/metrics.rst
@@ -9,6 +9,7 @@ Collection of functions for calculations of performance metrics.
    :caption: Submodule Reference
 
    entropy
+   zone_aggregation
 
 
 .. rubric:: Performance Metrics
@@ -18,3 +19,4 @@ Collection of functions for calculations of performance metrics.
    :nosignatures:
 
    entropy.approx_entropy
+   zone_aggregation.aggregate_property_by_zones

--- a/docs/source/modules/metrics/zone_aggregation.rst
+++ b/docs/source/modules/metrics/zone_aggregation.rst
@@ -1,0 +1,6 @@
+===================================
+floodlight.metrics.zone_aggregation
+===================================
+
+.. automodule:: floodlight.metrics.zone_aggregation
+    :members:

--- a/floodlight/metrics/zone_aggregation.py
+++ b/floodlight/metrics/zone_aggregation.py
@@ -1,0 +1,198 @@
+import numpy as np
+import pandas as pd
+
+from floodlight import PlayerProperty, TeamProperty
+from floodlight.utils.types import Numeric
+
+
+def aggregate_property_by_zones(
+    property_to_aggregate: PlayerProperty | TeamProperty,
+    binning_property: PlayerProperty | TeamProperty,
+    zones: list[tuple[Numeric, Numeric]],
+    zone_names: list[str] | None = None,
+    aggregation: str = "sum",
+) -> pd.DataFrame:
+    """Aggregates a property over threshold-based zones of another property.
+
+    This function bins frames based on the value of ``binning_property`` and
+    aggregates values from ``property_to_aggregate`` within each zone. Common use
+    cases include calculating distance covered per velocity zone or time spent in
+    different intensity zones.
+
+    Parameters
+    ----------
+    property_to_aggregate: PlayerProperty or TeamProperty
+        Property values to aggregate. For PlayerProperty, shape is (T, N) where T is
+        the number of frames and N is the number of players. For TeamProperty, shape
+        is (T,) where T is the number of frames.
+    binning_property: PlayerProperty or TeamProperty
+        Property values used to determine zone membership. Must have the same shape
+        as ``property_to_aggregate``.
+    zones: list[tuple[Numeric, Numeric]]
+        List of (min, max) threshold tuples defining each zone. Zones use half-open
+        intervals [min, max) where the minimum is inclusive and maximum is exclusive.
+        For example, [(0, 2), (2, 4)] creates two zones: [0, 2) and [2, 4).
+    zone_names: list[str], optional
+        Names for each zone. If None, zones are named as "**min** to **max**". Must
+        have the same length as ``zones`` if provided.
+    aggregation: str, optional
+        Aggregation function to apply within each zone. Options:
+        - 'sum': Sum of property values in zone
+        - 'count': Number of frames with valid data in zone
+        - 'mean': Average property value in zone
+        - 'min': Minimum property value in zone
+        - 'max': Maximum property value in zone
+        Default is 'sum'.
+
+    Returns
+    -------
+    zone_aggregates: pd.DataFrame
+        DataFrame with aggregated values. For PlayerProperty inputs, rows correspond
+        to players and columns to zones. For TeamProperty inputs, a single-row
+        DataFrame is returned. Empty zones (no frames matching) return NaN for
+        mean/min/max and 0 for sum/count.
+
+    Notes
+    -----
+    Valid property combinations:
+    - PlayerProperty by PlayerProperty: Both must have shape (T, N) with matching T and
+      N
+    - TeamProperty by TeamProperty: Both must have shape (T,) with matching T
+    - PlayerProperty by TeamProperty: Aggregation property has shape (T, N),
+      binning property has shape (T,). The binning values are broadcast across all
+      players.
+
+    Invalid combination:
+    - TeamProperty by PlayerProperty: Cannot bin a single team value using
+      player-specific thresholds.
+
+    Frames where either property has NaN values are excluded from all aggregations.
+    The boundary handling uses half-open intervals [min, max) to avoid ambiguity at
+    zone boundaries.
+
+    Examples
+    --------
+    Calculate distance covered in velocity zones for each player:
+
+    >>> from floodlight.models.kinematics import DistanceModel, VelocityModel
+    >>> # Fit models to XY data
+    >>> dm = DistanceModel()
+    >>> dm.fit(xy_data)
+    >>> distances = dm.cumulative_distance_covered()
+    >>> vm = VelocityModel()
+    >>> vm.fit(xy_data)
+    >>> velocities = vm.velocity()
+    >>> # Define velocity zones (m/s)
+    >>> zones = [(0, 2), (2, 4), (4, 7), (7, 100)]
+    >>> zone_names = ["Walking", "Jogging", "Running", "Sprinting"]
+    >>> result = aggregate_property_by_zones(
+    ...     distances, velocities, zones, zone_names, aggregation='sum'
+    ... )
+
+    Calculate time spent (frame count) in each metabolic power zone:
+
+    >>> from floodlight.models.kinetics import MetabolicPowerModel
+    >>> mpm = MetabolicPowerModel()
+    >>> mpm.fit(xy_data)
+    >>> power = mpm.metabolic_power()
+    >>> zones = [(0, 10), (10, 20), (20, 35), (35, 100)]
+    >>> result = aggregate_property_by_zones(
+    ...     power, power, zones, aggregation='count'
+    ... )
+
+    References
+    ----------
+    .. [1] `Miguel, M., Oliviera, R., Loureiro, N. Garcia-Rubio, J. & Ibáñez, S.
+        (2021). Load Measures in Training/Match Monitoring in Soccer: A Systematic
+        Review. International Journal of Environmental Research and Public Health,
+        18(5), 2721.<https://www.mdpi.com/1660-4601/18/5/2721>`_
+    """
+
+    n_zones = len(zones)
+
+    # Validate zone_names parameter
+    if zone_names is not None and len(zone_names) != n_zones:
+        raise ValueError(
+            f"zone_names length ({len(zone_names)}) must match zones length ({n_zones})"
+        )
+
+    # Generate default zone names if not provided
+    if zone_names is None:
+        zone_names = [f"{min_val} to {max_val}" for min_val, max_val in zones]
+
+    # Validate aggregation parameter
+    agg_funcs = {
+        "sum": lambda arr: np.nansum(arr, axis=0),
+        "count": lambda arr: np.sum(~arr.mask & ~np.isnan(arr.data), axis=0),
+        "mean": lambda arr: np.nanmean(arr, axis=0),
+        "min": lambda arr: np.nanmin(arr, axis=0),
+        "max": lambda arr: np.nanmax(arr, axis=0),
+    }
+
+    if aggregation not in agg_funcs:
+        raise ValueError(
+            f"aggregation must be one of {list(agg_funcs.keys())}, got '{aggregation}'"
+        )
+
+    agg_func = agg_funcs[aggregation]
+
+    # Get property arrays
+    prop_to_agg = property_to_aggregate.property
+    binning_prop = binning_property.property
+
+    # Validate property combination: TeamProperty by PlayerProperty is invalid
+    if prop_to_agg.ndim == 1 and binning_prop.ndim == 2:
+        raise ValueError(
+            "Cannot aggregate TeamProperty by PlayerProperty. "
+            "Valid combinations: PlayerProperty by PlayerProperty, "
+            "TeamProperty by TeamProperty, or PlayerProperty by TeamProperty."
+        )
+
+    # Validate matching time dimension
+    if prop_to_agg.shape[0] != binning_prop.shape[0]:
+        raise ValueError(
+            f"Time dimensions must match: property_to_aggregate has "
+            f"{prop_to_agg.shape[0]} frames but binning_property has "
+            f"{binning_prop.shape[0]} frames"
+        )
+
+    # Handle TeamProperty: reshape (T,) to (T, 1) for uniform processing
+    if prop_to_agg.ndim == 1:
+        prop_to_agg = prop_to_agg.reshape(-1, 1)
+        n_entities = 1
+    elif prop_to_agg.ndim == 2:
+        n_entities = prop_to_agg.shape[1]
+    else:
+        raise ValueError(
+            "property_to_aggregate must be 1D (TeamProperty) or 2D (PlayerProperty)"
+        )
+
+    if binning_prop.ndim == 1:
+        binning_prop = binning_prop.reshape(-1, 1)
+    elif binning_prop.ndim == 2:
+        # For PlayerProperty by PlayerProperty, validate matching N dimension
+        if prop_to_agg.shape[1] != binning_prop.shape[1]:
+            raise ValueError(
+                f"Player dimensions must match: property_to_aggregate has "
+                f"{prop_to_agg.shape[1]} players but binning_property has "
+                f"{binning_prop.shape[1]} players"
+            )
+
+    # Initialize output array
+    aggregated_values = np.full((n_entities, n_zones), np.nan)
+
+    # Loop over zones and aggregate
+    for i, (min_val, max_val) in enumerate(zones):
+        # Create mask for frames in this zone (half-open interval [min, max))
+        in_zone_mask = np.bitwise_and(binning_prop >= min_val, binning_prop < max_val)
+
+        # Mask the property to aggregate
+        masked_property = np.ma.masked_array(prop_to_agg, ~in_zone_mask)
+
+        # Apply aggregation function
+        aggregated_values[:, i] = agg_func(masked_property).data
+
+    # Create DataFrame with zone names as columns
+    zone_aggregates = pd.DataFrame(data=aggregated_values, columns=zone_names)
+
+    return zone_aggregates

--- a/floodlight/metrics/zone_aggregation.py
+++ b/floodlight/metrics/zone_aggregation.py
@@ -186,6 +186,10 @@ def aggregate_property_by_zones(
         # Create mask for frames in this zone (half-open interval [min, max))
         in_zone_mask = np.bitwise_and(binning_prop >= min_val, binning_prop < max_val)
 
+        # Broadcast mask if needed (PlayerProperty by TeamProperty case)
+        if in_zone_mask.shape != prop_to_agg.shape:
+            in_zone_mask = np.broadcast_to(in_zone_mask, prop_to_agg.shape)
+
         # Mask the property to aggregate
         masked_property = np.ma.masked_array(prop_to_agg, ~in_zone_mask)
 

--- a/tests/test_metrics/conftest.py
+++ b/tests/test_metrics/conftest.py
@@ -1,0 +1,99 @@
+import pytest
+import numpy as np
+
+from floodlight import PlayerProperty, TeamProperty
+
+
+# Basic PlayerProperty fixtures
+@pytest.fixture()
+def player_property_simple() -> PlayerProperty:
+    """Simple PlayerProperty with 6 frames, 2 players, clean data."""
+    prop = PlayerProperty(
+        property=np.array(
+            [[10, 100], [20, 200], [30, 300], [40, 400], [50, 500], [60, 600]],
+            dtype=float,
+        ),
+        name="values",
+    )
+    return prop
+
+
+@pytest.fixture()
+def player_property_binning() -> PlayerProperty:
+    """PlayerProperty for binning with varying values across zones."""
+    prop = PlayerProperty(
+        property=np.array(
+            [[0, 8], [1, 7], [2, 6], [3, 5], [4, 4], [5, 3]], dtype=float
+        ),
+        name="binning",
+    )
+    return prop
+
+
+# PlayerProperty with NaN values
+@pytest.fixture()
+def player_property_with_nans() -> PlayerProperty:
+    """PlayerProperty with NaN values in both players."""
+    prop = PlayerProperty(
+        property=np.array(
+            [[10, 10], [np.nan, 20], [30, np.nan], [40, 40], [50, 50], [60, 60]],
+            dtype=float,
+        ),
+        name="values",
+    )
+    return prop
+
+
+@pytest.fixture()
+def player_property_binning_with_nans() -> PlayerProperty:
+    """PlayerProperty for binning with NaN values."""
+    prop = PlayerProperty(
+        property=np.array(
+            [[1, 1], [np.nan, 2], [3, 3], [4, 4], [5, 5], [6, 6]], dtype=float
+        ),
+        name="binning",
+    )
+    return prop
+
+
+# TeamProperty fixtures
+@pytest.fixture()
+def team_property_simple() -> TeamProperty:
+    """Simple TeamProperty with 6 frames, clean data."""
+    prop = TeamProperty(
+        property=np.array([10, 20, 30, 40, 50, 60], dtype=float), name="values"
+    )
+    return prop
+
+
+@pytest.fixture()
+def team_property_binning() -> TeamProperty:
+    """TeamProperty for binning with varying values."""
+    prop = TeamProperty(
+        property=np.array([0, 1, 5, 6, 7, 8], dtype=float), name="binning"
+    )
+    return prop
+
+
+# Mismatched dimension fixtures for validation tests
+@pytest.fixture()
+def player_property_3_players() -> PlayerProperty:
+    """PlayerProperty with 3 players instead of 2."""
+    prop = PlayerProperty(
+        property=np.array(
+            [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12], [13, 14, 15], [16, 17, 18]],
+            dtype=float,
+        ),
+        name="values",
+    )
+    return prop
+
+
+@pytest.fixture()
+def player_property_4_frames() -> PlayerProperty:
+    """PlayerProperty with 4 frames instead of 6."""
+    prop = PlayerProperty(
+        property=np.array([[1, 2], [3, 4], [5, 6], [7, 8]], dtype=float),
+        name="values",
+    )
+    return prop

--- a/tests/test_metrics/test_zone_aggregation.py
+++ b/tests/test_metrics/test_zone_aggregation.py
@@ -1,0 +1,249 @@
+import pytest
+import numpy as np
+
+from floodlight import PlayerProperty
+from floodlight.metrics.zone_aggregation import aggregate_property_by_zones
+
+
+# Test basic sum aggregation with PlayerProperty
+@pytest.mark.unit
+def test_aggregate_property_by_zones_basic_sum(
+    player_property_simple, player_property_binning
+):
+    # Arrange
+    zones = [(0, 3), (3, 6), (6, 9)]
+    zone_names = ["Low", "Medium", "High"]
+
+    # Act
+    result = aggregate_property_by_zones(
+        player_property_simple,
+        player_property_binning,
+        zones,
+        zone_names,
+        aggregation="sum",
+    )
+
+    # Assert
+    assert result.shape == (2, 3)
+    assert list(result.columns) == ["Low", "Medium", "High"]
+    assert np.array_equal(result.iloc[0].values, [60.0, 150.0, 0.0])
+    assert np.array_equal(result.iloc[1].values, [0.0, 1500.0, 600.0])
+
+
+# Test count aggregation returns correct frame counts
+@pytest.mark.unit
+def test_aggregate_property_by_zones_count(
+    player_property_simple, player_property_binning
+):
+    # Arrange
+    zones = [(0, 4), (4, 8)]
+
+    # Act
+    result = aggregate_property_by_zones(
+        player_property_simple, player_property_binning, zones, aggregation="count"
+    )
+
+    # Assert
+    assert result.shape == (2, 2)
+    assert np.array_equal(result.iloc[0].values, [4.0, 2.0])
+    assert np.array_equal(result.iloc[1].values, [1.0, 4.0])
+
+
+# Test aggregation with TeamProperty inputs
+@pytest.mark.unit
+def test_aggregate_property_by_zones_team_property(
+    team_property_simple, team_property_binning
+):
+    # Arrange
+    zones = [(0, 2), (5, 9)]
+    zone_names = ["Low", "High"]
+
+    # Act
+    result = aggregate_property_by_zones(
+        team_property_simple,
+        team_property_binning,
+        zones,
+        zone_names,
+        aggregation="sum",
+    )
+
+    # Assert
+    assert result.shape == (1, 2)
+    assert list(result.columns) == ["Low", "High"]
+    assert np.array_equal(result.iloc[0].values, [30.0, 180.0])
+
+
+# Test PlayerProperty aggregated by TeamProperty (broadcasting)
+@pytest.mark.unit
+def test_aggregate_property_by_zones_player_by_team(
+    player_property_simple, team_property_binning
+):
+    # Arrange
+    zones = [(0, 2), (5, 9)]
+
+    # Act
+    result = aggregate_property_by_zones(
+        player_property_simple, team_property_binning, zones, aggregation="sum"
+    )
+
+    # Assert
+    assert result.shape == (2, 2)
+    assert np.array_equal(result.iloc[0].values, [30.0, 180.0])
+    assert np.array_equal(result.iloc[1].values, [300.0, 1800.0])
+
+
+# Test that NaN values in either property are excluded from aggregation
+@pytest.mark.unit
+def test_aggregate_property_by_zones_nan_handling(
+    player_property_with_nans, player_property_binning_with_nans
+):
+    # Arrange
+    zones = [(0, 7)]
+
+    # Act
+    result_sum = aggregate_property_by_zones(
+        player_property_with_nans,
+        player_property_binning_with_nans,
+        zones,
+        aggregation="sum",
+    )
+    result_count = aggregate_property_by_zones(
+        player_property_with_nans,
+        player_property_binning_with_nans,
+        zones,
+        aggregation="count",
+    )
+
+    # Assert
+    assert np.array_equal(result_sum.iloc[0].values, [190.0])
+    assert np.array_equal(result_sum.iloc[1].values, [180.0])
+    assert np.array_equal(result_count.iloc[0].values, [5.0])
+    assert np.array_equal(result_count.iloc[1].values, [5.0])
+
+
+# Test that zone boundaries use [min, max) (inclusive min, exclusive max)
+@pytest.mark.unit
+def test_aggregate_property_by_zones_boundary_handling():
+    # Arrange
+    binning = PlayerProperty(
+        property=np.array([[0], [2], [4], [6]], dtype=float), name="binning"
+    )
+    values = PlayerProperty(
+        property=np.array([[1], [1], [1], [1]], dtype=float), name="values"
+    )
+    zones = [(0, 2), (2, 4), (4, 6), (6, 8)]
+
+    # Act
+    result = aggregate_property_by_zones(values, binning, zones, aggregation="count")
+
+    # Assert
+    assert np.array_equal(result.iloc[0].values, [1.0, 1.0, 1.0, 1.0])
+
+
+# Test that empty zones return 0 for sum/count and NaN for mean
+@pytest.mark.unit
+def test_aggregate_property_by_zones_empty_zones(
+    player_property_simple, player_property_binning
+):
+    # Arrange
+    zones = [(0, 5), (10, 20)]
+
+    # Act
+    result_sum = aggregate_property_by_zones(
+        player_property_simple, player_property_binning, zones, aggregation="sum"
+    )
+    result_count = aggregate_property_by_zones(
+        player_property_simple, player_property_binning, zones, aggregation="count"
+    )
+    result_mean = aggregate_property_by_zones(
+        player_property_simple, player_property_binning, zones, aggregation="mean"
+    )
+
+    # Assert
+    assert result_sum.iloc[0, 1] == 0.0
+    assert result_sum.iloc[1, 1] == 0.0
+    assert result_count.iloc[0, 1] == 0.0
+    assert result_count.iloc[1, 1] == 0.0
+    assert np.isnan(result_mean.iloc[0, 1])
+    assert np.isnan(result_mean.iloc[1, 1])
+
+
+# Test that TeamProperty by PlayerProperty raises ValueError
+@pytest.mark.unit
+def test_aggregate_property_by_zones_invalid_team_by_player(
+    team_property_simple, player_property_binning
+):
+    # Arrange
+    zones = [(0, 5)]
+
+    # Act & Assert
+    with pytest.raises(
+        ValueError, match="Cannot aggregate TeamProperty by PlayerProperty"
+    ):
+        aggregate_property_by_zones(
+            team_property_simple, player_property_binning, zones, aggregation="sum"
+        )
+
+
+# Test that mismatched dimensions raise ValueError
+@pytest.mark.unit
+def test_aggregate_property_by_zones_mismatched_dimensions(
+    player_property_simple, player_property_3_players, player_property_4_frames
+):
+    # Arrange
+    zones = [(0, 5)]
+
+    # Act & Assert - mismatched player dimension
+    with pytest.raises(ValueError, match="Player dimensions must match"):
+        aggregate_property_by_zones(
+            player_property_simple, player_property_3_players, zones, aggregation="sum"
+        )
+
+    # Act & Assert - mismatched time dimension
+    with pytest.raises(ValueError, match="Time dimensions must match"):
+        aggregate_property_by_zones(
+            player_property_simple, player_property_4_frames, zones, aggregation="sum"
+        )
+
+
+# Test default zone name generation and single zone handling
+@pytest.mark.unit
+def test_aggregate_property_by_zones_default_names_and_single_zone():
+    # Arrange
+    values = PlayerProperty(property=np.array([[10]], dtype=float), name="values")
+    binning = PlayerProperty(property=np.array([[1]], dtype=float), name="binning")
+    zones = [(0, 5)]
+
+    # Act
+    result = aggregate_property_by_zones(values, binning, zones, aggregation="sum")
+
+    # Assert
+    assert list(result.columns) == ["0 to 5"]
+    assert result.shape == (1, 1)
+    assert np.array_equal(result.iloc[0].values, [10.0])
+
+
+# Test that all aggregation functions run correctly
+@pytest.mark.unit
+def test_aggregate_property_by_zones_all_aggregations(
+    player_property_simple, player_property_binning
+):
+    # Arrange
+    zones = [(0, 10)]
+
+    # Act & Assert
+    for agg in ["sum", "count", "mean", "min", "max"]:
+        result = aggregate_property_by_zones(
+            player_property_simple, player_property_binning, zones, aggregation=agg
+        )
+
+        assert result.shape == (2, 1)
+        assert not result.isnull().all().all()
+
+        if agg == "min":
+            assert result.iloc[0, 0] == 10.0
+        elif agg == "max":
+            assert result.iloc[0, 0] == 60.0
+        elif agg == "mean":
+            expected_mean = np.mean([10, 20, 30, 40, 50, 60])
+            assert result.iloc[0, 0] == expected_mean


### PR DESCRIPTION
This PR adds the function `aggregate_property_by_zones()` into the metrics module. The function can be used to bin and aggregate a `property` by zones of another `property`, usually used for intensity zones (e.g., distance covered in velocity zones).