### PR TITLE
fix: teamspread shape

### DIFF
--- a/floodlight/models/geometry.py
+++ b/floodlight/models/geometry.py
@@ -191,7 +191,7 @@ class CentroidModel(BaseModel):
         Returns
         -------
         stretch_index: TeamProperty
-            A TeamProperty object of shape (T, 1), where T is the total number of
+            A TeamProperty object of shape (T,), where T is the total number of
             frames. Each entry contains the stretch index of that particular frame.
         """
         # get player distances from centroid
@@ -253,8 +253,7 @@ class NearestMateModel(BaseModel):
     array([3.16227766, nan])
 
     >>> nmm.team_spread()
-    TeamProperty(property=array([[3.16227766],
-           [nan]]), name='team_spread', framerate=None)
+    TeamProperty(property=array([3.16227766, nan]), name='team_spread', framerate=None)
 
     References
     ----------
@@ -328,12 +327,12 @@ class NearestMateModel(BaseModel):
         Returns
         -------
         spread: TeamProperty
-            A TeamProperty object of shape (T, 1), where T is the total number of
+            A TeamProperty object of shape (T,), where T is the total number of
             frames. Each entry contains the team spread (Frobenius norm of the
             pairwise distance matrix) for that frame.
         """
         T = len(self._pairwise_distances_)
-        spread = np.full((T, 1), np.nan)
+        spread = np.full(T, np.nan)
 
         for t in range(T):
             distances = self._pairwise_distances_[t]

--- a/tests/test_models/test_geometry.py
+++ b/tests/test_models/test_geometry.py
@@ -132,7 +132,7 @@ def test_nearest_mate_model_team_spread(example_xy_object_geometry):
     spread = model.team_spread()
 
     # Assert
-    expected = np.array(((np.sqrt(10),), (np.nan,)))
+    expected = np.array((np.sqrt(10), np.nan))
     assert np.array_equal(spread.property, expected, equal_nan=True)
 
 
@@ -177,7 +177,7 @@ def test_nearest_mate_model_horizontal_nan_slice(
         )
     )
     assert np.array_equal(dtnm.property, expected_dtnm, equal_nan=True)
-    assert np.isnan(spread.property[1, 0])
+    assert np.isnan(spread.property[1])
 
 
 # Test NearestMateModel with single player
@@ -194,7 +194,7 @@ def test_nearest_mate_model_single_player(example_xy_object_single_player):
 
     # Assert
     expected_dtnm = np.array(((np.nan,), (np.nan,), (np.nan,)))
-    expected_spread = np.array(((np.nan,), (np.nan,), (np.nan,)))
+    expected_spread = np.array((np.nan, np.nan, np.nan))
     assert np.array_equal(dtnm.property, expected_dtnm, equal_nan=True)
     assert np.array_equal(spread.property, expected_spread, equal_nan=True)
 


### PR DESCRIPTION
Fixes the shape `NearestMateModel.team_spread()` return PlayerProperty from (T, 1) to (T,).