### PR TITLE
feat: temporal resample

### DIFF
--- a/docs/source/modules/transforms/temporal.rst
+++ b/docs/source/modules/transforms/temporal.rst
@@ -1,0 +1,6 @@
+==============================
+floodlight.transforms.temporal
+==============================
+
+.. automodule:: floodlight.transforms.temporal
+    :members:

--- a/docs/source/modules/transforms/transforms.rst
+++ b/docs/source/modules/transforms/transforms.rst
@@ -12,6 +12,7 @@ Collection of data transformation and processing functions.
    spatial
    permutation
    interpolation
+   temporal
 
 .. rubric:: Filter
 
@@ -48,3 +49,11 @@ Collection of data transformation and processing functions.
    interpolate_linear
    interpolate_polynomial
    interpolate_spline
+
+.. rubric:: Temporal
+
+.. currentmodule:: floodlight.transforms.temporal
+.. autosummary::
+   :nosignatures:
+
+   resample

--- a/floodlight/transforms/temporal.py
+++ b/floodlight/transforms/temporal.py
@@ -1,0 +1,307 @@
+from copy import deepcopy
+from typing import Union
+
+import numpy as np
+import scipy.interpolate
+
+from floodlight import Code, XY
+from floodlight.core.property import (
+    BaseProperty,
+    DyadicProperty,
+    PlayerProperty,
+    TeamProperty,
+)
+
+
+def _resample_array(
+    values: np.ndarray,
+    src_framerate: int,
+    tgt_framerate: int,
+    interp_method: Union[str, None],
+    order: int,
+    k: int,
+) -> np.ndarray:
+    """Core numerical resample routine.
+
+    Parameters
+    ----------
+    values: np.ndarray
+        Two-dimensional source array of shape ``(T, M)``. Callers flatten
+        higher-rank payloads to ``(T, M)`` before calling.
+    src_framerate, tgt_framerate: int
+        Source and target framerates in Hz.
+    interp_method: str or None
+        Interpolation method for the upsample path; ignored on the identity
+        and downsample paths.
+    order, k: int
+        Polynomial order / spline degree used by the respective methods.
+
+    Returns
+    -------
+    out: np.ndarray
+        Two-dimensional array of shape ``(N_out, M)``. Identity and
+        downsample paths preserve ``values.dtype``; the upsample path
+        returns ``float64`` to accommodate NaN.
+    """
+    # Empty-input short-circuit: bypass framerate math for T == 0 arrays.
+    if values.shape[0] == 0:
+        return values.copy()
+
+    if tgt_framerate == src_framerate:
+        resampled = deepcopy(values)
+    elif tgt_framerate < src_framerate:
+        resampled = _downsample(values, tgt_framerate, src_framerate)
+    else:
+        resampled = _upsample_columns(
+            values, src_framerate, tgt_framerate, interp_method, order, k
+        )
+
+    return resampled
+
+
+def _upsample_columns(
+    values: np.ndarray,
+    src_framerate: int,
+    tgt_framerate: int,
+    interp_method: Union[str, None],
+    order: int,
+    k: int,
+) -> np.ndarray:
+    """Per-column upsample helper.
+
+    Parameters
+    ----------
+    values: np.ndarray
+        Two-dimensional source array of shape ``(T, M)``.
+    src_framerate, tgt_framerate: int
+        Source and target framerates in Hz; ``tgt_framerate > src_framerate``.
+    interp_method: str or None
+        Interpolation method. ``None`` fills only target positions whose
+        time coincides with a source time and leaves the rest NaN.
+    order, k: int
+        Polynomial order / spline degree used by the respective methods.
+
+    Returns
+    -------
+    out: np.ndarray
+        Two-dimensional array of shape ``(N_out, M)`` and dtype ``float64``.
+    """
+    N_src = values.shape[0]
+    # Endpoint-inclusive length: last source sample aligns with last target sample.
+    N_out = (N_src - 1) * tgt_framerate // src_framerate + 1
+    M = values.shape[1]
+
+    min_required = {
+        None: 1,
+        "linear": 2,
+        "nearest": 1,
+        "polynomial": order + 1,
+        "spline": k + 1,
+    }[interp_method]
+    if N_src < min_required:
+        raise ValueError(
+            f"Method {interp_method!r} requires at least {min_required} source "
+            f"samples, got {N_src}."
+        )
+
+    src_times = np.arange(N_src, dtype=np.int64) / src_framerate
+    tgt_times = np.arange(N_out, dtype=np.int64) / tgt_framerate
+    out = np.full((N_out, M), np.nan, dtype=np.float64)
+
+    if interp_method is None:
+        # Fill only targets coinciding with source times; leave rest NaN.
+        aligned_targets = (np.arange(N_out) * src_framerate) % tgt_framerate == 0
+        aligned_src_idx = (np.arange(N_out) * src_framerate) // tgt_framerate
+
+    for j in range(M):
+        column_f = np.asarray(values[:, j], dtype=np.float64)
+        valid = ~np.isnan(column_f)
+        if not np.any(valid):
+            continue
+
+        xp = src_times[valid]
+        fp = column_f[valid]
+
+        if interp_method is None:
+            fill = aligned_targets & valid[aligned_src_idx]
+            out[fill, j] = column_f[aligned_src_idx[fill]]
+        elif interp_method == "linear":
+            out[:, j] = np.interp(tgt_times, xp, fp, left=np.nan, right=np.nan)
+        elif interp_method == "polynomial":
+            if xp.size < order + 1:
+                continue
+            spl = scipy.interpolate.make_interp_spline(xp, fp, k=order)
+            out[:, j] = spl(tgt_times, extrapolate=False)
+        elif interp_method == "spline":
+            if xp.size < k + 1:
+                continue
+            spl = scipy.interpolate.make_interp_spline(xp, fp, k=k)
+            out[:, j] = spl(tgt_times, extrapolate=False)
+        elif interp_method == "nearest":
+            # Earlier-source tie-break at midpoints.
+            idx_right = np.searchsorted(xp, tgt_times, side="left")
+            idx_right = np.clip(idx_right, 1, xp.size - 1)
+            idx_left = idx_right - 1
+            d_left = tgt_times - xp[idx_left]
+            d_right = xp[idx_right] - tgt_times
+            choose_left = d_left <= d_right
+            chosen = np.where(choose_left, idx_left, idx_right)
+            in_range = (tgt_times >= xp[0]) & (tgt_times <= xp[-1])
+            out[:, j] = np.where(in_range, fp[chosen], np.nan)
+
+    return out
+
+
+def _downsample(
+    values: np.ndarray,
+    tgt_framerate: int,
+    src_framerate: int,
+) -> np.ndarray:
+    """Nearest-sample downsample helper.
+
+    Parameters
+    ----------
+    values: np.ndarray
+        Two-dimensional source array of shape ``(T, M)``.
+    tgt_framerate, src_framerate: int
+        Target and source framerates in Hz; ``tgt_framerate < src_framerate``.
+
+    Returns
+    -------
+    out: np.ndarray
+        Two-dimensional array of shape ``(N_out, M)``; preserves ``values.dtype``.
+    """
+    N_src = values.shape[0]
+    N_out = (N_src - 1) * tgt_framerate // src_framerate + 1
+    # +tgt_framerate//2 rounds to the nearest source index instead of flooring.
+    src_idx = (np.arange(N_out) * src_framerate + tgt_framerate // 2) // tgt_framerate
+    src_idx = np.clip(src_idx, 0, N_src - 1)
+    resampled = values[src_idx].copy()
+    return resampled
+
+
+def resample(
+    obj: Union[XY, Code, TeamProperty, PlayerProperty, DyadicProperty],
+    target_framerate: int,
+    interp_method: Union[str, None] = None,
+    order: int = 3,
+    k: int = 3,
+) -> Union[XY, Code, TeamProperty, PlayerProperty, DyadicProperty]:
+    """Resample a floodlight core object to a new framerate.
+
+    Rescales any framerate-bearing core object (``XY``, ``Code``,
+    ``TeamProperty``, ``PlayerProperty``, or ``DyadicProperty``) to a target framerate.
+
+    Parameters
+    ----------
+    obj: XY | Code | TeamProperty | PlayerProperty | DyadicProperty
+        Framerate-bearing core object to resample.
+    target_framerate: int
+        Target framerate in Hz. Must be a positive integer.
+    interp_method : str or None, optional
+        Interpolation method for the upsample path. Must be one of
+        ``"linear"``, ``"polynomial"``, ``"spline"``, ``"nearest"`` or ``None``.
+        Default ``None``: new rows are left NaN, only target samples that coincide with
+        source samples take source values. Ignored on the identity and downsample paths.
+    order: int, optional
+        Polynomial order for ``interp_method="polynomial"``. Default 3.
+    k: int, optional
+        Spline degree for ``interp_method="spline"``. Default 3.
+
+    Returns
+    -------
+    obj_resampled: same type as ``obj``
+        New object with ``framerate`` rescaled to ``target_framerate``.
+
+    Notes
+    -----
+    In case of ``target_framerate == obj.framerate`` ``resample()`` returns a deep copy
+    of ``obj``.
+
+    Pre-existing NaN gaps in the source pass through unchanged on both the
+    upsample and downsample paths.
+
+    The downsample path uses an integer-math nearest-sample index formula;
+    ``interp_method`` is ignored there. No anti-aliasing filter is applied.
+    """
+    ALLOWED_METHODS = ("linear", "polynomial", "spline", "nearest")
+
+    if not isinstance(obj, (XY, Code, BaseProperty)):
+        raise ValueError(
+            f"Expected obj to be one of (XY, Code, TeamProperty, "
+            f"PlayerProperty, DyadicProperty), got {type(obj).__name__}."
+        )
+
+    if obj.framerate is None:
+        raise ValueError("Expected obj.framerate to be set, got None.")
+
+    if (
+        not isinstance(target_framerate, (int, np.integer))
+        or isinstance(target_framerate, bool)
+        or target_framerate <= 0
+    ):
+        raise ValueError(
+            f"Expected target_framerate to be a positive integer, "
+            f"got {target_framerate!r}."
+        )
+
+    if interp_method is not None and interp_method not in ALLOWED_METHODS:
+        raise ValueError(
+            f"Expected interp_method to be None or one of {ALLOWED_METHODS}, "
+            f"got {interp_method!r}."
+        )
+
+    if isinstance(obj, XY):
+        resampled_array = _resample_array(
+            obj.xy, obj.framerate, target_framerate, interp_method, order, k
+        )
+        resampled = XY(
+            xy=resampled_array,
+            framerate=target_framerate,
+            direction=deepcopy(obj.direction),
+        )
+    elif isinstance(obj, Code):
+        code_2d = np.asarray(obj.code).reshape(-1, 1)
+        resampled_2d = _resample_array(
+            code_2d, obj.framerate, target_framerate, interp_method, order, k
+        )
+        resampled = Code(
+            code=resampled_2d.reshape(-1),
+            name=deepcopy(obj.name),
+            definitions=deepcopy(obj.definitions),
+            framerate=target_framerate,
+        )
+    elif isinstance(obj, TeamProperty):
+        prop_2d = np.asarray(obj.property).reshape(-1, 1)
+        resampled_2d = _resample_array(
+            prop_2d, obj.framerate, target_framerate, interp_method, order, k
+        )
+        resampled = TeamProperty(
+            property=resampled_2d.reshape(-1),
+            name=deepcopy(obj.name),
+            framerate=target_framerate,
+        )
+    elif isinstance(obj, PlayerProperty):
+        resampled_array = _resample_array(
+            obj.property, obj.framerate, target_framerate, interp_method, order, k
+        )
+        resampled = PlayerProperty(
+            property=resampled_array,
+            name=deepcopy(obj.name),
+            framerate=target_framerate,
+        )
+    elif isinstance(obj, DyadicProperty):
+        prop = np.asarray(obj.property)
+        T, N1, N2 = prop.shape
+        prop_2d = prop.reshape(T, N1 * N2)
+        resampled_2d = _resample_array(
+            prop_2d, obj.framerate, target_framerate, interp_method, order, k
+        )
+        N_out = resampled_2d.shape[0]
+        resampled = DyadicProperty(
+            property=resampled_2d.reshape(N_out, N1, N2),
+            name=deepcopy(obj.name),
+            framerate=target_framerate,
+        )
+
+    return resampled

--- a/tests/test_transforms/conftest.py
+++ b/tests/test_transforms/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
-from floodlight import XY
+from floodlight import XY, Code
+from floodlight.core.property import TeamProperty, PlayerProperty, DyadicProperty
 
 
 @pytest.fixture()
@@ -137,3 +138,46 @@ def example_xy_permutation():
         framerate=10,
     )
     return xy
+
+
+@pytest.fixture()
+def example_code_temporal():
+    code = Code(
+        code=np.array([0, 0, 1, 1, 2, 2, 1, 1, 0, 0], dtype=int),
+        name="possession",
+        definitions={0: "none", 1: "home", 2: "away"},
+        framerate=50,
+    )
+    return code
+
+
+@pytest.fixture()
+def example_team_property_temporal():
+    prop = TeamProperty(
+        property=np.arange(10, dtype=float),
+        name="stretch_index",
+        framerate=50,
+    )
+    return prop
+
+
+@pytest.fixture()
+def example_player_property_temporal():
+    prop = PlayerProperty(
+        property=np.arange(30, dtype=float).reshape(10, 3),
+        name="speed",
+        framerate=50,
+    )
+    return prop
+
+
+@pytest.fixture()
+def example_dyadic_property_temporal():
+    # Asymmetric shape N_1=2, N_2=3 -> (10, 2, 3) guards against any accidental
+    # N_1 == N_2 assumption in resample's DyadicProperty adapter.
+    prop = DyadicProperty(
+        property=np.arange(60, dtype=float).reshape(10, 2, 3),
+        name="distance",
+        framerate=50,
+    )
+    return prop

--- a/tests/test_transforms/test_temporal.py
+++ b/tests/test_transforms/test_temporal.py
@@ -1,0 +1,311 @@
+import numpy as np
+import pytest
+
+from floodlight import XY, Code
+from floodlight.core.property import PlayerProperty, DyadicProperty, TeamProperty
+from floodlight.transforms.temporal import resample
+
+
+# --- Core path: identity, downsample, upsample ---
+
+
+@pytest.mark.unit
+def test_resample_identity(example_xy_spatial: XY) -> None:
+    # Arrange
+    xy = example_xy_spatial  # framerate=10, direction="lr", T=3
+
+    # Act
+    xy_out = resample(xy, 10, interp_method="spline")
+
+    # Assert — bit-equal payload, metadata preserved, fresh object
+    assert isinstance(xy_out, XY)
+    assert np.array_equal(xy_out.xy, xy.xy)
+    assert xy_out.framerate == 10
+    assert xy_out.direction == "lr"
+    assert xy_out is not xy
+    assert xy_out.xy is not xy.xy
+
+
+@pytest.mark.unit
+def test_resample_downsample_default(example_xy_permutation: XY) -> None:
+    # Arrange
+    xy = example_xy_permutation
+
+    # Act
+    xy_out = resample(xy, 5)
+
+    # Assert
+    expected = np.array(
+        [
+            [0.0, 0.0, 10.0, 0.0, 5.0, 10.0],
+            [5.0, 10.0, 0.0, 0.0, 10.0, 0.0],
+        ]
+    )
+    assert np.array_equal(xy_out.xy, expected)
+    assert xy_out.framerate == 5
+    assert isinstance(xy_out.framerate, int)
+
+
+@pytest.mark.unit
+def test_resample_upsample_linear(example_xy_permutation: XY) -> None:
+    # Arrange
+    xy = example_xy_permutation
+
+    # Act
+    xy_out = resample(xy, 20, interp_method="linear")
+
+    # Assert
+    expected = np.array(
+        [
+            [0.0, 0.0, 10.0, 0.0, 5.0, 10.0],
+            [5.0, 0.0, 5.0, 0.0, 5.0, 10.0],
+            [10.0, 0.0, 0.0, 0.0, 5.0, 10.0],
+            [7.5, 5.0, 0.0, 0.0, 7.5, 5.0],
+            [5.0, 10.0, 0.0, 0.0, 10.0, 0.0],
+            [2.5, 5.0, 2.5, 5.0, 10.0, 0.0],
+            [0.0, 0.0, 5.0, 10.0, 10.0, 0.0],
+        ]
+    )
+    assert np.array_equal(np.round(xy_out.xy, 4), expected)
+    assert xy_out.framerate == 20
+    assert isinstance(xy_out.framerate, int)
+
+
+@pytest.mark.unit
+def test_resample_upsample_polynomial(example_xy_permutation: XY) -> None:
+    # Arrange
+    xy = example_xy_permutation
+
+    # Act
+    xy_out = resample(xy, 20, interp_method="polynomial")
+
+    # Assert
+    expected = np.array(
+        [
+            [0.0, 0.0, 10.0, 0.0, 5.0, 10.0],
+            [7.8125, -3.125, 3.4375, 0.625, 3.75, 12.5],
+            [10.0, 0.0, 0.0, 0.0, 5.0, 10.0],
+            [8.4375, 5.625, -0.9375, -0.625, 7.5, 5.0],
+            [5.0, 10.0, 0.0, 0.0, 10.0, 0.0],
+            [1.5625, 9.375, 2.1875, 3.125, 11.25, -2.5],
+            [0.0, 0.0, 5.0, 10.0, 10.0, 0.0],
+        ]
+    )
+    assert np.array_equal(np.round(xy_out.xy, 4), expected)
+    assert xy_out.framerate == 20
+
+
+@pytest.mark.unit
+def test_resample_upsample_spline(example_xy_permutation: XY) -> None:
+    # Arrange
+    xy = example_xy_permutation
+
+    # Act
+    xy_out = resample(xy, 20, interp_method="spline")
+
+    # Assert
+    expected = np.array(
+        [
+            [0.0, 0.0, 10.0, 0.0, 5.0, 10.0],
+            [7.8125, -3.125, 3.4375, 0.625, 3.75, 12.5],
+            [10.0, 0.0, 0.0, 0.0, 5.0, 10.0],
+            [8.4375, 5.625, -0.9375, -0.625, 7.5, 5.0],
+            [5.0, 10.0, 0.0, 0.0, 10.0, 0.0],
+            [1.5625, 9.375, 2.1875, 3.125, 11.25, -2.5],
+            [0.0, 0.0, 5.0, 10.0, 10.0, 0.0],
+        ]
+    )
+    assert np.array_equal(np.round(xy_out.xy, 4), expected)
+    assert xy_out.framerate == 20
+
+
+@pytest.mark.unit
+def test_resample_upsample_nearest(example_xy_permutation: XY) -> None:
+    # Arrange
+    xy = example_xy_permutation
+
+    # Act
+    xy_out = resample(xy, 20, interp_method="nearest")
+
+    # Assert
+    expected = np.array(
+        [
+            [0.0, 0.0, 10.0, 0.0, 5.0, 10.0],
+            [0.0, 0.0, 10.0, 0.0, 5.0, 10.0],
+            [10.0, 0.0, 0.0, 0.0, 5.0, 10.0],
+            [10.0, 0.0, 0.0, 0.0, 5.0, 10.0],
+            [5.0, 10.0, 0.0, 0.0, 10.0, 0.0],
+            [5.0, 10.0, 0.0, 0.0, 10.0, 0.0],
+            [0.0, 0.0, 5.0, 10.0, 10.0, 0.0],
+        ]
+    )
+    assert np.array_equal(xy_out.xy, expected)
+    assert xy_out.framerate == 20
+
+
+@pytest.mark.unit
+def test_resample_tie_break_30_to_20() -> None:
+    # Arrange
+    xy = XY(
+        np.array([[k, k] for k in range(7)], dtype=float),
+        framerate=30,
+    )
+
+    # Act
+    xy_out = resample(xy, 20)
+
+    # Assert
+    assert xy_out.xy.shape == (5, 2)
+    assert np.array_equal(xy_out.xy[:, 0], np.array([0, 2, 3, 5, 6], dtype=float))
+    assert xy_out.framerate == 20
+
+
+# --- Type dispatch ---
+
+
+@pytest.mark.unit
+def test_resample_dispatch_code(example_code_temporal: Code) -> None:
+    # Arrange
+    code = example_code_temporal
+
+    # Act
+    code_out = resample(code, 25)
+
+    # Assert
+    assert isinstance(code_out, Code)
+    assert code_out.code.shape == (5,)
+    assert code_out.framerate == 25
+    assert code_out.name == "possession"
+    assert code_out.definitions == {0: "none", 1: "home", 2: "away"}
+
+
+@pytest.mark.unit
+def test_resample_dispatch_team_property(
+    example_team_property_temporal: TeamProperty,
+) -> None:
+    # Arrange
+    prop = example_team_property_temporal
+
+    # Act
+    prop_out = resample(prop, 25)
+
+    # Assert
+    assert prop_out.property.shape == (5,)
+    assert prop_out.framerate == 25
+    assert prop_out.name == "stretch_index"
+    assert np.array_equal(prop_out.property, prop.property[::2])
+
+
+@pytest.mark.unit
+def test_resample_dispatch_player_property(
+    example_player_property_temporal: PlayerProperty,
+) -> None:
+    # Arrange
+    prop = example_player_property_temporal
+
+    # Act
+    prop_out = resample(prop, 25)
+
+    # Assert
+    assert isinstance(prop_out, PlayerProperty)
+    assert prop_out.property.shape == (5, 3)
+    assert prop_out.framerate == 25
+    assert prop_out.name == "speed"
+
+
+@pytest.mark.unit
+def test_resample_dispatch_dyadic_property(
+    example_dyadic_property_temporal: DyadicProperty,
+) -> None:
+    # Arrange
+    prop = example_dyadic_property_temporal
+
+    # Act
+    prop_out = resample(prop, 25)
+
+    # Assert
+    assert isinstance(prop_out, DyadicProperty)
+    assert prop_out.property.shape == (5, 2, 3)
+    assert prop_out.framerate == 25
+    assert prop_out.name == "distance"
+
+
+# --- Side-effect / invariant tests ---
+
+
+@pytest.mark.unit
+def test_resample_nan_passthrough(example_xy_filter: XY) -> None:
+    # Arrange
+    xy = example_xy_filter
+
+    # Act
+    xy_out = resample(xy, 10, interp_method="linear")
+
+    # Assert
+    assert np.all(np.isnan(xy_out.xy[:, 2].astype(float)))
+
+
+# --- Edge cases and errors ---
+
+
+@pytest.mark.unit
+def test_resample_empty(example_xy_filter_empty: XY) -> None:
+    # Arrange
+    xy = example_xy_filter_empty
+
+    # Act
+    xy_out = resample(xy, 10, interp_method="spline")
+
+    # Assert
+    assert isinstance(xy_out, XY)
+    assert xy_out.xy.shape == (0,)
+    assert xy_out.framerate == 10
+
+
+@pytest.mark.unit
+def test_resample_spline_insufficient_samples_raises(
+    example_xy_filter_short: XY,
+) -> None:
+    # Arrange
+    xy = example_xy_filter_short
+
+    # Act & Assert
+    with pytest.raises(
+        ValueError,
+        match=r"Method 'spline' requires at least 4 source samples, got 2\.",
+    ):
+        resample(xy, 40, interp_method="spline")
+
+
+@pytest.mark.unit
+def test_resample_framerate_none_raises() -> None:
+    # Arrange
+    xy = XY(np.arange(20, dtype=float).reshape(10, 2))
+
+    # Act & Assert
+    with pytest.raises(
+        ValueError, match=r"Expected obj\.framerate to be set, got None\."
+    ):
+        resample(xy, 25)
+
+
+@pytest.mark.unit
+def test_resample_target_zero_raises(example_xy_spatial: XY) -> None:
+    # Arrange
+    xy = example_xy_spatial
+
+    # Act & Assert
+    with pytest.raises(
+        ValueError, match=r"Expected target_framerate to be a positive integer"
+    ):
+        resample(xy, 0)
+
+
+@pytest.mark.unit
+def test_resample_unsupported_type_raises() -> None:
+    # Arrange
+    not_a_core_object = np.array([1.0, 2.0, 3.0])
+
+    # Act & Assert
+    with pytest.raises(ValueError, match=r"Expected obj to be one of"):
+        resample(not_a_core_object, 25)


### PR DESCRIPTION
This PR adds `floodlight.transforms.temporal.resample()` that resamples any framerate-bearing core object (XY, Code, TeamProperty, PlayerProperty, DyadicProperty) to an arbitrary target framerate. Donwsampling is done via nearest-sample index. Upsampled data is padded with nans and can be interpolated via linear, polynomial and spline interpolation, preserving pre-existing nan gaps.