### PR TITLE
fix: compare SkillCorner ball IDs by value

### DIFF
--- a/floodlight/io/skillcorner.py
+++ b/floodlight/io/skillcorner.py
@@ -236,7 +236,7 @@ def read_position_data_json(
                     y_column = x_column + 1
                     xy_objects[half]["Away"][t, x_column] = tracked_object["x"]
                     xy_objects[half]["Away"][t, y_column] = tracked_object["y"]
-                elif pID is ball_id:
+                elif pID == ball_id:
                     xy_objects[half]["Ball"][t, 0] = tracked_object["x"]
                     xy_objects[half]["Ball"][t, 1] = tracked_object["y"]
                 # do not track referee

--- a/tests/test_io/test_skillcorner.py
+++ b/tests/test_io/test_skillcorner.py
@@ -1,0 +1,49 @@
+import json
+
+import numpy as np
+
+from floodlight.io.skillcorner import read_position_data_json
+
+
+def test_read_position_data_associates_ball_id_by_value(tmp_path):
+    ball_id = 98765432109876543210987654321
+    home_id = 71000000000000000000000000001
+    away_id = 72000000000000000000000000002
+    match = {
+        "home_team": {"id": 101},
+        "away_team": {"id": 202},
+        "referees": [],
+        "ball": {"trackable_object": ball_id},
+        "players": [
+            {"team_id": 101, "trackable_object": home_id},
+            {"team_id": 202, "trackable_object": away_id},
+        ],
+        "pitch_length": 105.0,
+        "pitch_width": 68.0,
+    }
+    positions = [
+        {
+            "period": 1,
+            "possession": {"group": "home team", "trackable_object": home_id},
+            "data": [
+                {"trackable_object": home_id, "x": 1.25, "y": 2.5},
+                {"trackable_object": away_id, "x": -4.75, "y": 5.5},
+                {"trackable_object": ball_id, "x": 12.5, "y": -3.25},
+            ],
+        }
+    ]
+    match_path = tmp_path / "match.json"
+    positions_path = tmp_path / "positions.json"
+    # Separate files require identifier linkage across independent JSON decodes.
+    match_path.write_text(json.dumps(match), encoding="utf-8")
+    positions_path.write_text(json.dumps(positions), encoding="utf-8")
+
+    xy, _, _, _, _ = read_position_data_json(str(positions_path), str(match_path))
+
+    ball = xy["firstHalf"]["Ball"]
+    np.testing.assert_array_equal(ball.xy, [[12.5, -3.25]])
+    assert np.isfinite(ball.xy).all()
+    np.testing.assert_array_equal(xy["firstHalf"]["Home"].xy, [[1.25, 2.5]])
+    np.testing.assert_array_equal(xy["firstHalf"]["Away"].xy, [[-4.75, 5.5]])
+    assert ball.xy.shape == (1, 2)
+    assert ball.framerate == 10


### PR DESCRIPTION
## Summary

The SkillCorner parser currently associates ball observations using Python object identity:

```python
pID is ball_id
```

Match metadata and positional tracking data are decoded from separate JSON files. Equal provider identifiers are therefore not guaranteed to refer to the same Python object, even though they represent the same ball.

This can silently leave valid ball coordinates as `NaN`.

## Change

Use identifier value equality for ball association:

```python
pID == ball_id
```

The production change is limited to this predicate.

## Regression protection

Added a compact synthetic regression test that:

* Writes match metadata and positional observations to independent JSON files.
* Calls the public `read_position_data_json` parser.
* Uses value-equal ball identifiers decoded independently.
* Verifies the exact expected ball coordinates.
* Verifies Home and Away player coordinates remain correct.
* Verifies the ball output shape and framerate.

No proprietary provider data are included.

## Measured result

On the deterministic regression fixture:

| Metric                                 |       Before |           After |
| -------------------------------------- | -----------: | --------------: |
| Correctly associated ball observations |          0/1 |             1/1 |
| Ball-association recall                |           0% |            100% |
| Returned ball coordinate               | `[NaN, NaN]` | `[12.5, -3.25]` |
| Valid ball rows left `NaN`             |            1 |               0 |
| Coordinate error                       |            — |    `[0.0, 0.0]` |

Home and Away control outputs remain unchanged.

## Validation

* Focused SkillCorner regression: `1 passed`
* SkillCorner test module: `1 passed`
* IO test suite: `9 passed`
* Full test suite: `280 passed`
* CI-equivalent full suite with coverage: `280 passed`
* Pre-commit: passed
* Black: passed
* Changed-file flake8: passed with zero findings
* Import smoke: passed
* Package build: passed

The full-repository flake8 output retains exactly two pre-existing unrelated `E226` findings. This change introduces no new lint findings.

## Scope

This PR does not change:

* SkillCorner schema support
* Coordinate handling
* Framerate
* Possession handling
* Filtering or interpolation
* Ball smoothing
* Other provider integrations
* Public API structure
* Dependencies
